### PR TITLE
Refactor Oracle Feeder to Use Updated Parachain Interface and MinerId Format

### DIFF
--- a/src/feeder.rs
+++ b/src/feeder.rs
@@ -1,10 +1,16 @@
 use crate::{
-    block_tracker::BlockTracker, error::Error, substrate_interface::api::runtime_types::cyborg_primitives::{oracle::{OracleKey, OracleValue}, task::TaskKind}, tx_queue::{TxOutput, TRANSACTION_QUEUE}
+    block_tracker::BlockTracker,
+    error::Error,
+    substrate_interface::api::runtime_types::cyborg_primitives::{
+        oracle::{OracleKey, OracleValue},
+        task::TaskKind,
+    },
+    tx_queue::{TxOutput, TRANSACTION_QUEUE},
 };
 use async_trait::async_trait;
 use ezkl::Commitments;
 use reqwest::Client;
-use subxt::{blocks::Block, utils::AccountId32, OnlineClient, PolkadotConfig};
+use subxt::{blocks::Block, OnlineClient, PolkadotConfig};
 use subxt_signer::sr25519::Keypair;
 use tokio::{
     sync::{Mutex, RwLock},
@@ -22,8 +28,8 @@ use crate::substrate_interface::{
         runtime_types::{
             bounded_collections::bounded_vec::BoundedVec,
             cyborg_primitives::{
-                oracle::{OracleMinerFormat, ProcessStatus},
                 miner::MinerType,
+                oracle::{OracleMinerFormat, ProcessStatus},
             },
         },
     },
@@ -38,7 +44,7 @@ use std::{fs::write, sync::Arc};
 use tempfile::tempdir;
 
 pub struct SharedState {
-    pub current_miners_data: Mutex<Option<Vec<(OracleKey<AccountId32>, OracleValue)>>>,
+    pub current_miners_data: Mutex<Option<Vec<(OracleKey, OracleValue)>>>,
 }
 
 #[allow(dead_code)]
@@ -65,7 +71,7 @@ impl Clone for MinerType {
         }
     }
 }
-impl Clone for OracleMinerFormat<AccountId32> {
+impl Clone for OracleMinerFormat {
     fn clone(&self) -> Self {
         OracleMinerFormat {
             id: self.id.clone(),
@@ -73,7 +79,7 @@ impl Clone for OracleMinerFormat<AccountId32> {
         }
     }
 }
-impl Clone for OracleKey<AccountId32> {
+impl Clone for OracleKey {
     fn clone(&self) -> Self {
         match self {
             Self::Miner(miner) => Self::Miner(miner.clone()),
@@ -251,8 +257,9 @@ impl OracleFeeder for CyborgOracleFeeder {
             return Err("Task is not an NZK task!".into());
         };
 
-        let proof = nzk_data.zk_proof
-            .ok_or(Error::Custom("No ZK proof present for verification, nzk_data.zk_proof is none!".to_string()))?;
+        let proof = nzk_data.zk_proof.ok_or(Error::Custom(
+            "No ZK proof present for verification, nzk_data.zk_proof is none!".to_string(),
+        ))?;
 
         let dir = tempdir()?;
         let proof_path = dir.path().join("proof.json");
@@ -292,15 +299,14 @@ impl OracleFeeder for CyborgOracleFeeder {
             _ => return Err("Verification failed".into()),
         };
 
-        let result: (OracleKey<AccountId32>, OracleValue) = (
+        let result: (OracleKey, OracleValue) = (
             OracleKey::NzkProofResult(task_id),
             OracleValue::ZkProofResult(bool_result),
         );
 
         let result = vec![result];
 
-        let feed_oracle_tx =
-            SubstrateApi::tx().oracle().feed_values(BoundedVec(result));
+        let feed_oracle_tx = SubstrateApi::tx().oracle().feed_values(BoundedVec(result));
 
         println!(
             "Feed Oracle NeuroZk Parameters: {:?}",
@@ -353,15 +359,11 @@ impl OracleFeeder for CyborgOracleFeeder {
     }
 
     async fn collect_miner_data(&self) -> Result<(), subxt::Error> {
-        let mut new_miner_data: Vec<(OracleKey<AccountId32>, OracleValue)> = Vec::new();
+        let mut new_miner_data: Vec<(OracleKey, OracleValue)> = Vec::new();
 
-        let miner_clusters_address = SubstrateApi::storage()
-            .edge_connect()
-            .cloud_miners_iter();
+        let miner_clusters_address = SubstrateApi::storage().edge_connect().cloud_miners_iter();
 
-        let executable_miners_address = SubstrateApi::storage()
-            .edge_connect()
-            .edge_miners_iter();
+        let executable_miners_address = SubstrateApi::storage().edge_connect().edge_miners_iter();
 
         let client = CLIENT.get().ok_or("Failed to get client")?;
 
@@ -390,7 +392,7 @@ impl OracleFeeder for CyborgOracleFeeder {
 
             new_miner_data.push((
                 OracleKey::Miner(OracleMinerFormat {
-                    id: (miner.value.owner, miner.value.id),
+                    id: miner.value.id,
                     miner_type: MinerType::Edge,
                 }),
                 OracleValue::MinerStatus(process_status),
@@ -403,11 +405,10 @@ impl OracleFeeder for CyborgOracleFeeder {
             println!("Miner IP: {}", miner_ip);
 
             let process_status = self.get_miner_data(&miner_ip).await;
-            
 
             new_miner_data.push((
                 OracleKey::Miner(OracleMinerFormat {
-                    id: (miner.value.owner, miner.value.id),
+                    id: miner.value.id,
                     miner_type: MinerType::Edge,
                 }),
                 OracleValue::MinerStatus(process_status),
@@ -467,10 +468,7 @@ impl OracleFeeder for CyborgOracleFeeder {
                 }
             }
             Err(error) => {
-                println!(
-                    "Miner with ip {} is not online. Error: {}",
-                    miner_ip, error
-                );
+                println!("Miner with ip {} is not online. Error: {}", miner_ip, error);
                 ProcessStatus {
                     online: false,
                     available: false,

--- a/src/feeder.rs
+++ b/src/feeder.rs
@@ -18,7 +18,6 @@ use tokio::{
 };
 //use rand::rngs::StdRng;
 //use rand::{Rng, SeedableRng};
-//use crate::substrate_interface::api::edge_connect::storage::types::executable_miners;
 use crate::account::load_cyborg_test_key;
 use crate::config::CLIENT;
 use crate::substrate_interface::{
@@ -361,29 +360,29 @@ impl OracleFeeder for CyborgOracleFeeder {
     async fn collect_miner_data(&self) -> Result<(), subxt::Error> {
         let mut new_miner_data: Vec<(OracleKey, OracleValue)> = Vec::new();
 
-        let miner_clusters_address = SubstrateApi::storage().edge_connect().cloud_miners_iter();
+        let cloud_miners_address = SubstrateApi::storage().edge_connect().cloud_miners_iter();
 
-        let executable_miners_address = SubstrateApi::storage().edge_connect().edge_miners_iter();
+        let edge_miners_address = SubstrateApi::storage().edge_connect().edge_miners_iter();
 
         let client = CLIENT.get().ok_or("Failed to get client")?;
 
-        let mut miner_clusters_query = client
+        let mut cloud_miners_query = client
             .storage()
             .at_latest()
             .await?
-            .iter(miner_clusters_address)
+            .iter(cloud_miners_address)
             .await?;
 
-        let mut executable_miners_query = client
+        let mut edge_miners_query = client
             .storage()
             .at_latest()
             .await?
-            .iter(executable_miners_address)
+            .iter(edge_miners_address)
             .await?;
 
         println!("Collecting miner data...");
 
-        while let Some(Ok(miner)) = miner_clusters_query.next().await {
+        while let Some(Ok(miner)) = cloud_miners_query.next().await {
             let miner_ip = String::from_utf8_lossy(&miner.value.api.domain.0).to_string();
 
             println!("Miner IP: {}", miner_ip);
@@ -399,7 +398,7 @@ impl OracleFeeder for CyborgOracleFeeder {
             ));
         }
 
-        while let Some(Ok(miner)) = executable_miners_query.next().await {
+        while let Some(Ok(miner)) = edge_miners_query.next().await {
             let miner_ip = String::from_utf8_lossy(&miner.value.api.domain.0).to_string();
 
             println!("Miner IP: {}", miner_ip);

--- a/src/feeder.rs
+++ b/src/feeder.rs
@@ -403,6 +403,7 @@ impl OracleFeeder for CyborgOracleFeeder {
             println!("Miner IP: {}", miner_ip);
 
             let process_status = self.get_miner_data(&miner_ip).await;
+            
 
             new_miner_data.push((
                 OracleKey::Miner(OracleMinerFormat {

--- a/src/substrate_interface.rs
+++ b/src/substrate_interface.rs
@@ -1325,10 +1325,9 @@ pub mod api {
                         "query_call_info",
                         types::QueryCallInfo { call, len },
                         [
-                            113u8, 113u8, 128u8, 147u8, 43u8, 188u8, 48u8, 108u8, 64u8, 244u8,
-                            181u8, 31u8, 67u8, 187u8, 147u8, 163u8, 221u8, 18u8, 69u8, 201u8,
-                            226u8, 217u8, 70u8, 177u8, 204u8, 160u8, 248u8, 181u8, 176u8, 252u8,
-                            133u8, 119u8,
+                            220u8, 27u8, 225u8, 249u8, 147u8, 134u8, 12u8, 222u8, 175u8, 162u8,
+                            254u8, 165u8, 56u8, 249u8, 210u8, 73u8, 147u8, 27u8, 16u8, 97u8, 21u8,
+                            120u8, 130u8, 87u8, 152u8, 236u8, 84u8, 88u8, 166u8, 4u8, 149u8, 199u8,
                         ],
                     )
                 }
@@ -1346,10 +1345,10 @@ pub mod api {
                         "query_call_fee_details",
                         types::QueryCallFeeDetails { call, len },
                         [
-                            222u8, 243u8, 254u8, 199u8, 231u8, 133u8, 188u8, 15u8, 67u8, 171u8,
-                            15u8, 27u8, 75u8, 148u8, 213u8, 16u8, 126u8, 6u8, 59u8, 83u8, 131u8,
-                            43u8, 47u8, 64u8, 195u8, 67u8, 138u8, 153u8, 138u8, 118u8, 122u8,
-                            184u8,
+                            75u8, 85u8, 235u8, 209u8, 74u8, 242u8, 174u8, 187u8, 180u8, 106u8,
+                            254u8, 49u8, 229u8, 246u8, 94u8, 202u8, 208u8, 127u8, 120u8, 51u8,
+                            89u8, 179u8, 139u8, 53u8, 40u8, 67u8, 32u8, 214u8, 186u8, 105u8, 196u8,
+                            0u8,
                         ],
                     )
                 }
@@ -1765,9 +1764,10 @@ pub mod api {
                         "get_recent_events",
                         types::GetRecentEvents {},
                         [
-                            121u8, 211u8, 110u8, 66u8, 0u8, 93u8, 216u8, 249u8, 97u8, 124u8, 255u8,
-                            32u8, 131u8, 16u8, 93u8, 47u8, 57u8, 30u8, 57u8, 72u8, 186u8, 133u8,
-                            10u8, 86u8, 98u8, 16u8, 247u8, 152u8, 186u8, 150u8, 253u8, 253u8,
+                            103u8, 222u8, 13u8, 169u8, 226u8, 147u8, 32u8, 225u8, 72u8, 178u8,
+                            199u8, 72u8, 73u8, 42u8, 130u8, 78u8, 255u8, 25u8, 236u8, 243u8, 47u8,
+                            231u8, 48u8, 200u8, 115u8, 159u8, 30u8, 33u8, 126u8, 46u8, 150u8,
+                            248u8,
                         ],
                     )
                 }
@@ -2001,9 +2001,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                86u8, 8u8, 38u8, 194u8, 128u8, 60u8, 118u8, 91u8, 121u8, 54u8, 75u8, 133u8, 248u8,
-                219u8, 220u8, 10u8, 214u8, 4u8, 241u8, 208u8, 250u8, 44u8, 195u8, 35u8, 164u8,
-                192u8, 160u8, 153u8, 237u8, 140u8, 241u8, 6u8,
+                13u8, 171u8, 50u8, 153u8, 41u8, 80u8, 241u8, 84u8, 102u8, 138u8, 213u8, 158u8,
+                238u8, 32u8, 179u8, 171u8, 235u8, 7u8, 18u8, 209u8, 23u8, 223u8, 15u8, 13u8, 36u8,
+                254u8, 52u8, 116u8, 64u8, 192u8, 69u8, 225u8,
             ]
     }
     pub mod system {
@@ -3192,10 +3192,10 @@ pub mod api {
                         "Events",
                         (),
                         [
-                            20u8, 61u8, 21u8, 15u8, 160u8, 161u8, 76u8, 117u8, 30u8, 70u8, 169u8,
-                            182u8, 112u8, 144u8, 153u8, 211u8, 223u8, 0u8, 163u8, 246u8, 103u8,
-                            40u8, 246u8, 179u8, 197u8, 162u8, 183u8, 29u8, 193u8, 138u8, 230u8,
-                            15u8,
+                            192u8, 234u8, 63u8, 136u8, 193u8, 164u8, 107u8, 15u8, 135u8, 108u8,
+                            148u8, 42u8, 246u8, 114u8, 172u8, 50u8, 36u8, 252u8, 226u8, 174u8,
+                            75u8, 223u8, 6u8, 232u8, 192u8, 118u8, 74u8, 204u8, 159u8, 165u8,
+                            179u8, 115u8,
                         ],
                     )
                 }
@@ -6697,9 +6697,9 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            91u8, 241u8, 38u8, 199u8, 40u8, 62u8, 152u8, 67u8, 1u8, 23u8, 49u8,
-                            59u8, 99u8, 227u8, 161u8, 89u8, 35u8, 196u8, 244u8, 109u8, 19u8, 137u8,
-                            147u8, 134u8, 75u8, 85u8, 172u8, 53u8, 231u8, 179u8, 161u8, 154u8,
+                            115u8, 235u8, 171u8, 252u8, 186u8, 64u8, 168u8, 196u8, 70u8, 144u8,
+                            222u8, 165u8, 87u8, 44u8, 194u8, 87u8, 249u8, 140u8, 120u8, 92u8, 62u8,
+                            227u8, 14u8, 145u8, 146u8, 80u8, 66u8, 193u8, 114u8, 66u8, 54u8, 207u8,
                         ],
                     )
                 }
@@ -6722,9 +6722,10 @@ pub mod api {
                             weight,
                         },
                         [
-                            42u8, 185u8, 32u8, 194u8, 117u8, 190u8, 217u8, 255u8, 203u8, 149u8,
-                            158u8, 251u8, 158u8, 231u8, 58u8, 93u8, 79u8, 149u8, 140u8, 120u8, 9u8,
-                            37u8, 179u8, 66u8, 205u8, 63u8, 85u8, 215u8, 98u8, 62u8, 143u8, 220u8,
+                            91u8, 64u8, 191u8, 189u8, 102u8, 174u8, 197u8, 98u8, 3u8, 107u8, 202u8,
+                            135u8, 141u8, 6u8, 191u8, 239u8, 124u8, 218u8, 232u8, 8u8, 110u8,
+                            251u8, 11u8, 93u8, 137u8, 171u8, 241u8, 146u8, 112u8, 139u8, 160u8,
+                            121u8,
                         ],
                     )
                 }
@@ -6764,10 +6765,10 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            183u8, 228u8, 246u8, 141u8, 61u8, 207u8, 160u8, 82u8, 72u8, 47u8,
-                            157u8, 234u8, 36u8, 148u8, 206u8, 145u8, 3u8, 194u8, 206u8, 168u8,
-                            35u8, 255u8, 39u8, 131u8, 199u8, 190u8, 30u8, 218u8, 6u8, 115u8, 83u8,
-                            150u8,
+                            7u8, 9u8, 16u8, 39u8, 36u8, 152u8, 26u8, 117u8, 35u8, 198u8, 17u8,
+                            89u8, 199u8, 192u8, 241u8, 213u8, 183u8, 210u8, 11u8, 4u8, 205u8,
+                            218u8, 170u8, 47u8, 56u8, 7u8, 200u8, 209u8, 227u8, 202u8, 191u8,
+                            252u8,
                         ],
                     )
                 }
@@ -13150,9 +13151,7 @@ pub mod api {
                     use super::runtime_types;
                     pub type Values =
                         runtime_types::bounded_collections::bounded_vec::BoundedVec<(
-                            runtime_types::cyborg_primitives::oracle::OracleKey<
-                                ::subxt::ext::subxt_core::utils::AccountId32,
-                            >,
+                            runtime_types::cyborg_primitives::oracle::OracleKey,
                             runtime_types::cyborg_primitives::oracle::OracleValue,
                         )>;
                 }
@@ -13176,10 +13175,9 @@ pub mod api {
                         "feed_values",
                         types::FeedValues { values },
                         [
-                            222u8, 59u8, 219u8, 184u8, 217u8, 219u8, 61u8, 245u8, 110u8, 11u8,
-                            136u8, 176u8, 5u8, 19u8, 20u8, 17u8, 57u8, 52u8, 205u8, 227u8, 54u8,
-                            213u8, 138u8, 142u8, 122u8, 4u8, 219u8, 237u8, 96u8, 108u8, 212u8,
-                            131u8,
+                            83u8, 92u8, 128u8, 102u8, 146u8, 202u8, 242u8, 138u8, 35u8, 124u8,
+                            73u8, 89u8, 97u8, 207u8, 201u8, 96u8, 78u8, 1u8, 30u8, 19u8, 21u8,
+                            199u8, 53u8, 3u8, 130u8, 69u8, 36u8, 157u8, 235u8, 241u8, 45u8, 153u8,
                         ],
                     )
                 }
@@ -13209,9 +13207,7 @@ pub mod api {
                 use super::runtime_types;
                 pub type Sender = ::subxt::ext::subxt_core::utils::AccountId32;
                 pub type Values = ::subxt::ext::subxt_core::alloc::vec::Vec<(
-                    runtime_types::cyborg_primitives::oracle::OracleKey<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >,
+                    runtime_types::cyborg_primitives::oracle::OracleKey,
                     runtime_types::cyborg_primitives::oracle::OracleValue,
                 )>;
             }
@@ -13231,9 +13227,7 @@ pub mod api {
                         ::core::primitive::u64,
                     >;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = runtime_types::cyborg_primitives::oracle::OracleKey<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param1 = runtime_types::cyborg_primitives::oracle::OracleKey;
                 }
                 pub mod values {
                     use super::runtime_types;
@@ -13241,9 +13235,7 @@ pub mod api {
                         runtime_types::cyborg_primitives::oracle::OracleValue,
                         ::core::primitive::u64,
                     >;
-                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleKey<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleKey;
                 }
                 pub mod has_dispatched {
                     use super::runtime_types;
@@ -13269,9 +13261,10 @@ pub mod api {
                         "RawValues",
                         (),
                         [
-                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
-                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
-                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
+                            222u8, 169u8, 253u8, 90u8, 2u8, 159u8, 172u8, 152u8, 130u8, 140u8,
+                            128u8, 202u8, 99u8, 168u8, 90u8, 132u8, 253u8, 223u8, 120u8, 176u8,
+                            50u8, 232u8, 8u8, 249u8, 7u8, 4u8, 70u8, 155u8, 223u8, 100u8, 93u8,
+                            93u8,
                         ],
                     )
                 }
@@ -13295,9 +13288,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
-                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
-                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
+                            222u8, 169u8, 253u8, 90u8, 2u8, 159u8, 172u8, 152u8, 130u8, 140u8,
+                            128u8, 202u8, 99u8, 168u8, 90u8, 132u8, 253u8, 223u8, 120u8, 176u8,
+                            50u8, 232u8, 8u8, 249u8, 7u8, 4u8, 70u8, 155u8, 223u8, 100u8, 93u8,
+                            93u8,
                         ],
                     )
                 }
@@ -13332,9 +13326,10 @@ pub mod api {
                             ),
                         ),
                         [
-                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
-                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
-                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
+                            222u8, 169u8, 253u8, 90u8, 2u8, 159u8, 172u8, 152u8, 130u8, 140u8,
+                            128u8, 202u8, 99u8, 168u8, 90u8, 132u8, 253u8, 223u8, 120u8, 176u8,
+                            50u8, 232u8, 8u8, 249u8, 7u8, 4u8, 70u8, 155u8, 223u8, 100u8, 93u8,
+                            93u8,
                         ],
                     )
                 }
@@ -13353,10 +13348,9 @@ pub mod api {
                         "Values",
                         (),
                         [
-                            134u8, 60u8, 119u8, 192u8, 231u8, 75u8, 113u8, 140u8, 58u8, 158u8,
-                            93u8, 229u8, 132u8, 108u8, 122u8, 143u8, 49u8, 192u8, 237u8, 175u8,
-                            206u8, 82u8, 15u8, 15u8, 34u8, 91u8, 118u8, 78u8, 14u8, 219u8, 153u8,
-                            236u8,
+                            242u8, 56u8, 242u8, 132u8, 129u8, 96u8, 111u8, 68u8, 116u8, 43u8,
+                            180u8, 169u8, 4u8, 5u8, 41u8, 227u8, 231u8, 245u8, 127u8, 157u8, 109u8,
+                            124u8, 198u8, 85u8, 87u8, 223u8, 88u8, 69u8, 14u8, 141u8, 203u8, 135u8,
                         ],
                     )
                 }
@@ -13380,10 +13374,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            134u8, 60u8, 119u8, 192u8, 231u8, 75u8, 113u8, 140u8, 58u8, 158u8,
-                            93u8, 229u8, 132u8, 108u8, 122u8, 143u8, 49u8, 192u8, 237u8, 175u8,
-                            206u8, 82u8, 15u8, 15u8, 34u8, 91u8, 118u8, 78u8, 14u8, 219u8, 153u8,
-                            236u8,
+                            242u8, 56u8, 242u8, 132u8, 129u8, 96u8, 111u8, 68u8, 116u8, 43u8,
+                            180u8, 169u8, 4u8, 5u8, 41u8, 227u8, 231u8, 245u8, 127u8, 157u8, 109u8,
+                            124u8, 198u8, 85u8, 87u8, 223u8, 88u8, 69u8, 14u8, 141u8, 203u8, 135u8,
                         ],
                     )
                 }
@@ -14163,7 +14156,6 @@ pub mod api {
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
                 pub struct PenalizeMiner {
-                    pub miner_owner: penalize_miner::MinerOwner,
                     pub miner_id: penalize_miner::MinerId,
                     pub miner_type: penalize_miner::MinerType,
                     pub penalty: penalize_miner::Penalty,
@@ -14171,7 +14163,6 @@ pub mod api {
                 }
                 pub mod penalize_miner {
                     use super::runtime_types;
-                    pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
                     pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
@@ -14200,7 +14191,6 @@ pub mod api {
                 )]
                 #[doc = "Manually suspend a miner (root only)"]
                 pub struct SuspendMiner {
-                    pub miner_owner: suspend_miner::MinerOwner,
                     pub miner_id: suspend_miner::MinerId,
                     pub miner_type: suspend_miner::MinerType,
                     pub blocks: suspend_miner::Blocks,
@@ -14208,7 +14198,6 @@ pub mod api {
                 }
                 pub mod suspend_miner {
                     use super::runtime_types;
-                    pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
                     pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
@@ -14237,14 +14226,12 @@ pub mod api {
                 )]
                 #[doc = "Manually ban a miner (root only)"]
                 pub struct BanMiner {
-                    pub miner_owner: ban_miner::MinerOwner,
                     pub miner_id: ban_miner::MinerId,
                     pub miner_type: ban_miner::MinerType,
                     pub reason: ban_miner::Reason,
                 }
                 pub mod ban_miner {
                     use super::runtime_types;
-                    pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
                     pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
@@ -14272,13 +14259,11 @@ pub mod api {
                 )]
                 #[doc = "Lift suspension from a miner (root only)"]
                 pub struct UnsuspendMiner {
-                    pub miner_owner: unsuspend_miner::MinerOwner,
                     pub miner_id: unsuspend_miner::MinerId,
                     pub miner_type: unsuspend_miner::MinerType,
                 }
                 pub mod unsuspend_miner {
                     use super::runtime_types;
-                    pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
                     pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
@@ -14407,7 +14392,6 @@ pub mod api {
                 }
                 pub fn penalize_miner(
                     &self,
-                    miner_owner: types::penalize_miner::MinerOwner,
                     miner_id: types::penalize_miner::MinerId,
                     miner_type: types::penalize_miner::MinerType,
                     penalty: types::penalize_miner::Penalty,
@@ -14418,24 +14402,22 @@ pub mod api {
                         "EdgeConnect",
                         "penalize_miner",
                         types::PenalizeMiner {
-                            miner_owner,
                             miner_id,
                             miner_type,
                             penalty,
                             reason,
                         },
                         [
-                            186u8, 124u8, 226u8, 63u8, 56u8, 203u8, 187u8, 178u8, 195u8, 95u8,
-                            112u8, 227u8, 237u8, 181u8, 102u8, 73u8, 166u8, 215u8, 252u8, 15u8,
-                            210u8, 50u8, 58u8, 156u8, 216u8, 120u8, 160u8, 14u8, 227u8, 253u8,
-                            112u8, 203u8,
+                            176u8, 193u8, 161u8, 39u8, 152u8, 137u8, 109u8, 143u8, 227u8, 41u8,
+                            232u8, 21u8, 34u8, 129u8, 61u8, 176u8, 84u8, 168u8, 184u8, 187u8,
+                            180u8, 18u8, 107u8, 22u8, 124u8, 227u8, 3u8, 168u8, 158u8, 240u8, 22u8,
+                            116u8,
                         ],
                     )
                 }
                 #[doc = "Manually suspend a miner (root only)"]
                 pub fn suspend_miner(
                     &self,
-                    miner_owner: types::suspend_miner::MinerOwner,
                     miner_id: types::suspend_miner::MinerId,
                     miner_type: types::suspend_miner::MinerType,
                     blocks: types::suspend_miner::Blocks,
@@ -14446,23 +14428,21 @@ pub mod api {
                         "EdgeConnect",
                         "suspend_miner",
                         types::SuspendMiner {
-                            miner_owner,
                             miner_id,
                             miner_type,
                             blocks,
                             reason,
                         },
                         [
-                            116u8, 15u8, 51u8, 159u8, 199u8, 117u8, 39u8, 137u8, 28u8, 55u8, 147u8,
-                            237u8, 207u8, 59u8, 64u8, 131u8, 100u8, 142u8, 138u8, 209u8, 247u8,
-                            122u8, 219u8, 223u8, 16u8, 140u8, 98u8, 35u8, 73u8, 24u8, 201u8, 238u8,
+                            181u8, 182u8, 20u8, 224u8, 159u8, 36u8, 217u8, 92u8, 0u8, 12u8, 129u8,
+                            186u8, 61u8, 197u8, 212u8, 119u8, 64u8, 104u8, 21u8, 151u8, 62u8, 56u8,
+                            65u8, 58u8, 114u8, 91u8, 99u8, 166u8, 237u8, 12u8, 142u8, 179u8,
                         ],
                     )
                 }
                 #[doc = "Manually ban a miner (root only)"]
                 pub fn ban_miner(
                     &self,
-                    miner_owner: types::ban_miner::MinerOwner,
                     miner_id: types::ban_miner::MinerId,
                     miner_type: types::ban_miner::MinerType,
                     reason: types::ban_miner::Reason,
@@ -14472,22 +14452,21 @@ pub mod api {
                         "EdgeConnect",
                         "ban_miner",
                         types::BanMiner {
-                            miner_owner,
                             miner_id,
                             miner_type,
                             reason,
                         },
                         [
-                            57u8, 221u8, 144u8, 19u8, 2u8, 94u8, 161u8, 151u8, 81u8, 68u8, 175u8,
-                            123u8, 252u8, 132u8, 181u8, 246u8, 63u8, 23u8, 21u8, 118u8, 79u8, 53u8,
-                            85u8, 235u8, 199u8, 154u8, 217u8, 212u8, 16u8, 205u8, 8u8, 80u8,
+                            218u8, 90u8, 143u8, 85u8, 163u8, 38u8, 252u8, 220u8, 29u8, 149u8,
+                            195u8, 237u8, 103u8, 169u8, 89u8, 168u8, 63u8, 211u8, 134u8, 61u8,
+                            178u8, 157u8, 3u8, 251u8, 8u8, 16u8, 243u8, 0u8, 175u8, 230u8, 79u8,
+                            147u8,
                         ],
                     )
                 }
                 #[doc = "Lift suspension from a miner (root only)"]
                 pub fn unsuspend_miner(
                     &self,
-                    miner_owner: types::unsuspend_miner::MinerOwner,
                     miner_id: types::unsuspend_miner::MinerId,
                     miner_type: types::unsuspend_miner::MinerType,
                 ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<types::UnsuspendMiner>
@@ -14496,14 +14475,13 @@ pub mod api {
                         "EdgeConnect",
                         "unsuspend_miner",
                         types::UnsuspendMiner {
-                            miner_owner,
                             miner_id,
                             miner_type,
                         },
                         [
-                            53u8, 169u8, 208u8, 100u8, 14u8, 117u8, 137u8, 147u8, 233u8, 80u8,
-                            14u8, 41u8, 36u8, 238u8, 173u8, 19u8, 55u8, 124u8, 133u8, 97u8, 170u8,
-                            31u8, 224u8, 12u8, 166u8, 230u8, 88u8, 82u8, 30u8, 199u8, 25u8, 191u8,
+                            126u8, 162u8, 139u8, 161u8, 193u8, 160u8, 252u8, 88u8, 151u8, 150u8,
+                            162u8, 185u8, 50u8, 239u8, 68u8, 228u8, 252u8, 127u8, 80u8, 92u8, 74u8,
+                            141u8, 218u8, 181u8, 24u8, 176u8, 4u8, 128u8, 35u8, 142u8, 16u8, 139u8,
                         ],
                     )
                 }
@@ -14720,12 +14698,9 @@ pub mod api {
             }
             pub mod miner_penalized {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
                 pub type Penalty = ::core::primitive::i32;
                 pub type Reason = runtime_types::pallet_edge_connect::pallet::PenaltyReason;
             }
@@ -14751,12 +14726,9 @@ pub mod api {
             }
             pub mod miner_suspended {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
                 pub type UntilBlock = ::core::primitive::u32;
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerSuspended {
@@ -14781,12 +14753,9 @@ pub mod api {
             }
             pub mod miner_under_review {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
                 pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerUnderReview {
@@ -14811,12 +14780,9 @@ pub mod api {
             }
             pub mod miner_banned {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
                 pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerBanned {
@@ -14840,12 +14806,9 @@ pub mod api {
             }
             pub mod miner_unsuspended {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerUnsuspended {
                 const PALLET: &'static str = "EdgeConnect";
@@ -14870,8 +14833,7 @@ pub mod api {
                         ::core::primitive::u32,
                         runtime_types::cyborg_primitives::miner::SuspensionReason,
                     );
-                    pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    pub type Param0 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
                 }
@@ -14882,8 +14844,7 @@ pub mod api {
                         ::core::primitive::u32,
                         ::core::primitive::u64,
                     >;
-                    pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    pub type Param0 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
                 }
@@ -14894,8 +14855,7 @@ pub mod api {
                         ::core::primitive::u32,
                         ::core::primitive::u64,
                     >;
-                    pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    pub type Param0 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
                 }
@@ -14965,13 +14925,13 @@ pub mod api {
                         "SuspendedMiners",
                         (),
                         [
-                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
-                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
-                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
+                            3u8, 80u8, 150u8, 127u8, 134u8, 183u8, 68u8, 110u8, 87u8, 46u8, 190u8,
+                            147u8, 91u8, 86u8, 37u8, 52u8, 175u8, 185u8, 157u8, 67u8, 35u8, 180u8,
+                            24u8, 250u8, 196u8, 50u8, 17u8, 108u8, 198u8, 176u8, 237u8, 219u8,
                         ],
                     )
                 }
-                pub fn suspended_miners_iter1(
+                pub fn suspended_miners(
                     &self,
                     _0: impl ::core::borrow::Borrow<types::suspended_miners::Param0>,
                 ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
@@ -14979,9 +14939,9 @@ pub mod api {
                         types::suspended_miners::Param0,
                     >,
                     types::suspended_miners::SuspendedMiners,
-                    (),
-                    (),
                     ::subxt::ext::subxt_core::utils::Yes,
+                    (),
+                    (),
                 > {
                     ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
                         "EdgeConnect",
@@ -14990,45 +14950,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
-                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
-                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
-                        ],
-                    )
-                }
-                pub fn suspended_miners(
-                    &self,
-                    _0: impl ::core::borrow::Borrow<types::suspended_miners::Param0>,
-                    _1: impl ::core::borrow::Borrow<types::suspended_miners::Param1>,
-                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
-                    (
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::suspended_miners::Param0,
-                        >,
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::suspended_miners::Param1,
-                        >,
-                    ),
-                    types::suspended_miners::SuspendedMiners,
-                    ::subxt::ext::subxt_core::utils::Yes,
-                    (),
-                    (),
-                > {
-                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
-                        "EdgeConnect",
-                        "SuspendedMiners",
-                        (
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _0.borrow(),
-                            ),
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _1.borrow(),
-                            ),
-                        ),
-                        [
-                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
-                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
-                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
+                            3u8, 80u8, 150u8, 127u8, 134u8, 183u8, 68u8, 110u8, 87u8, 46u8, 190u8,
+                            147u8, 91u8, 86u8, 37u8, 52u8, 175u8, 185u8, 157u8, 67u8, 35u8, 180u8,
+                            24u8, 250u8, 196u8, 50u8, 17u8, 108u8, 198u8, 176u8, 237u8, 219u8,
                         ],
                     )
                 }
@@ -15047,14 +14971,15 @@ pub mod api {
                         "CloudMiners",
                         (),
                         [
-                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
-                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
-                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
+                            233u8, 26u8, 119u8, 12u8, 199u8, 211u8, 224u8, 187u8, 216u8, 141u8,
+                            201u8, 77u8, 38u8, 49u8, 86u8, 67u8, 138u8, 154u8, 142u8, 155u8, 234u8,
+                            189u8, 184u8, 69u8, 173u8, 243u8, 77u8, 80u8, 131u8, 129u8, 255u8,
+                            215u8,
                         ],
                     )
                 }
                 #[doc = " Cloud Miner information, Storage map to keep track of detailed miner information for each (account ID, miner ID) pair."]
-                pub fn cloud_miners_iter1(
+                pub fn cloud_miners(
                     &self,
                     _0: impl ::core::borrow::Borrow<types::cloud_miners::Param0>,
                 ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
@@ -15062,9 +14987,9 @@ pub mod api {
                         types::cloud_miners::Param0,
                     >,
                     types::cloud_miners::CloudMiners,
-                    (),
-                    (),
                     ::subxt::ext::subxt_core::utils::Yes,
+                    (),
+                    (),
                 > {
                     ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
                         "EdgeConnect",
@@ -15073,46 +14998,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
-                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
-                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
-                        ],
-                    )
-                }
-                #[doc = " Cloud Miner information, Storage map to keep track of detailed miner information for each (account ID, miner ID) pair."]
-                pub fn cloud_miners(
-                    &self,
-                    _0: impl ::core::borrow::Borrow<types::cloud_miners::Param0>,
-                    _1: impl ::core::borrow::Borrow<types::cloud_miners::Param1>,
-                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
-                    (
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::cloud_miners::Param0,
-                        >,
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::cloud_miners::Param1,
-                        >,
-                    ),
-                    types::cloud_miners::CloudMiners,
-                    ::subxt::ext::subxt_core::utils::Yes,
-                    (),
-                    (),
-                > {
-                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
-                        "EdgeConnect",
-                        "CloudMiners",
-                        (
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _0.borrow(),
-                            ),
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _1.borrow(),
-                            ),
-                        ),
-                        [
-                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
-                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
-                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
+                            233u8, 26u8, 119u8, 12u8, 199u8, 211u8, 224u8, 187u8, 216u8, 141u8,
+                            201u8, 77u8, 38u8, 49u8, 86u8, 67u8, 138u8, 154u8, 142u8, 155u8, 234u8,
+                            189u8, 184u8, 69u8, 173u8, 243u8, 77u8, 80u8, 131u8, 129u8, 255u8,
+                            215u8,
                         ],
                     )
                 }
@@ -15131,14 +15020,15 @@ pub mod api {
                         "EdgeMiners",
                         (),
                         [
-                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
-                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
-                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
+                            220u8, 231u8, 97u8, 172u8, 214u8, 247u8, 184u8, 97u8, 122u8, 30u8,
+                            135u8, 248u8, 124u8, 187u8, 57u8, 65u8, 202u8, 100u8, 176u8, 57u8,
+                            65u8, 27u8, 209u8, 70u8, 38u8, 158u8, 19u8, 207u8, 97u8, 172u8, 18u8,
+                            5u8,
                         ],
                     )
                 }
                 #[doc = " Edge Miner information, Storage map to keep track of detailed miner information for each (account ID, miner ID) pair."]
-                pub fn edge_miners_iter1(
+                pub fn edge_miners(
                     &self,
                     _0: impl ::core::borrow::Borrow<types::edge_miners::Param0>,
                 ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
@@ -15146,9 +15036,9 @@ pub mod api {
                         types::edge_miners::Param0,
                     >,
                     types::edge_miners::EdgeMiners,
-                    (),
-                    (),
                     ::subxt::ext::subxt_core::utils::Yes,
+                    (),
+                    (),
                 > {
                     ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
                         "EdgeConnect",
@@ -15157,46 +15047,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
-                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
-                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
-                        ],
-                    )
-                }
-                #[doc = " Edge Miner information, Storage map to keep track of detailed miner information for each (account ID, miner ID) pair."]
-                pub fn edge_miners(
-                    &self,
-                    _0: impl ::core::borrow::Borrow<types::edge_miners::Param0>,
-                    _1: impl ::core::borrow::Borrow<types::edge_miners::Param1>,
-                ) -> ::subxt::ext::subxt_core::storage::address::StaticAddress<
-                    (
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::edge_miners::Param0,
-                        >,
-                        ::subxt::ext::subxt_core::storage::address::StaticStorageKey<
-                            types::edge_miners::Param1,
-                        >,
-                    ),
-                    types::edge_miners::EdgeMiners,
-                    ::subxt::ext::subxt_core::utils::Yes,
-                    (),
-                    (),
-                > {
-                    ::subxt::ext::subxt_core::storage::address::StaticAddress::new_static(
-                        "EdgeConnect",
-                        "EdgeMiners",
-                        (
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _0.borrow(),
-                            ),
-                            ::subxt::ext::subxt_core::storage::address::StaticStorageKey::new(
-                                _1.borrow(),
-                            ),
-                        ),
-                        [
-                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
-                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
-                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
+                            220u8, 231u8, 97u8, 172u8, 214u8, 247u8, 184u8, 97u8, 122u8, 30u8,
+                            135u8, 248u8, 124u8, 187u8, 57u8, 65u8, 202u8, 100u8, 176u8, 57u8,
+                            65u8, 27u8, 209u8, 70u8, 38u8, 158u8, 19u8, 207u8, 97u8, 172u8, 18u8,
+                            5u8,
                         ],
                     )
                 }
@@ -15424,6 +15278,38 @@ pub mod api {
                     const PALLET: &'static str = "TaskManagement";
                     const CALL: &'static str = "get_model_hash";
                 }
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                #[doc = "Reset a stuck task and its associated miner (sudo only)"]
+                #[doc = "This allows manual intervention for tasks that are stuck in Assigned, Running, or Stopped states"]
+                pub struct ResetTask {
+                    pub task_id: reset_task::TaskId,
+                    pub miner_type: reset_task::MinerType,
+                    pub reason: reset_task::Reason,
+                }
+                pub mod reset_task {
+                    use super::runtime_types;
+                    pub type TaskId = ::core::primitive::u64;
+                    pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
+                    pub type Reason = runtime_types::pallet_task_management::pallet::ResetReason;
+                }
+                impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for ResetTask {
+                    const PALLET: &'static str = "TaskManagement";
+                    const CALL: &'static str = "reset_task";
+                }
             }
             pub struct TransactionApi;
             impl TransactionApi {
@@ -15566,6 +15452,30 @@ pub mod api {
                             197u8, 17u8, 4u8, 61u8, 236u8, 30u8, 165u8, 250u8, 17u8, 239u8, 167u8,
                             123u8, 163u8, 127u8, 136u8, 43u8, 181u8, 114u8, 110u8, 131u8, 13u8,
                             45u8, 140u8, 163u8, 120u8, 100u8, 2u8, 4u8, 139u8, 157u8, 231u8, 230u8,
+                        ],
+                    )
+                }
+                #[doc = "Reset a stuck task and its associated miner (sudo only)"]
+                #[doc = "This allows manual intervention for tasks that are stuck in Assigned, Running, or Stopped states"]
+                pub fn reset_task(
+                    &self,
+                    task_id: types::reset_task::TaskId,
+                    miner_type: types::reset_task::MinerType,
+                    reason: types::reset_task::Reason,
+                ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<types::ResetTask>
+                {
+                    ::subxt::ext::subxt_core::tx::payload::StaticPayload::new_static(
+                        "TaskManagement",
+                        "reset_task",
+                        types::ResetTask {
+                            task_id,
+                            miner_type,
+                            reason,
+                        },
+                        [
+                            1u8, 243u8, 127u8, 76u8, 35u8, 255u8, 227u8, 157u8, 246u8, 24u8, 76u8,
+                            134u8, 227u8, 255u8, 37u8, 83u8, 173u8, 82u8, 57u8, 58u8, 114u8, 85u8,
+                            163u8, 184u8, 91u8, 223u8, 38u8, 42u8, 72u8, 149u8, 23u8, 184u8,
                         ],
                     )
                 }
@@ -15730,6 +15640,36 @@ pub mod api {
                 const PALLET: &'static str = "TaskManagement";
                 const EVENT: &'static str = "ModelHashQueried";
             }
+            #[derive(
+                :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                Debug,
+            )]
+            # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+            #[codec(dumb_trait_bound)]
+            #[decode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode")]
+            #[encode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode")]
+            #[doc = "Event emitted when a task is manually reset by admin"]
+            pub struct TaskManuallyReset {
+                pub task_id: task_manually_reset::TaskId,
+                pub reset_by: task_manually_reset::ResetBy,
+                pub previous_status: task_manually_reset::PreviousStatus,
+                pub reason: task_manually_reset::Reason,
+            }
+            pub mod task_manually_reset {
+                use super::runtime_types;
+                pub type TaskId = ::core::primitive::u64;
+                pub type ResetBy =
+                    ::core::option::Option<::subxt::ext::subxt_core::utils::AccountId32>;
+                pub type PreviousStatus = runtime_types::cyborg_primitives::task::TaskStatusType;
+                pub type Reason = runtime_types::pallet_task_management::pallet::ResetReason;
+            }
+            impl ::subxt::ext::subxt_core::events::StaticEvent for TaskManuallyReset {
+                const PALLET: &'static str = "TaskManagement";
+                const EVENT: &'static str = "TaskManuallyReset";
+            }
         }
         pub mod storage {
             use super::runtime_types;
@@ -15742,12 +15682,10 @@ pub mod api {
                 }
                 pub mod task_allocations {
                     use super::runtime_types;
-                    pub type TaskAllocations = (
-                        ::subxt::ext::subxt_core::utils::AccountId32,
+                    pub type TaskAllocations =
                         runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
-                        >,
-                    );
+                        >;
                     pub type Param0 = ::core::primitive::u64;
                 }
                 pub mod task_owners {
@@ -15867,10 +15805,9 @@ pub mod api {
                         "TaskAllocations",
                         (),
                         [
-                            232u8, 188u8, 42u8, 109u8, 42u8, 237u8, 157u8, 203u8, 58u8, 216u8,
-                            39u8, 134u8, 215u8, 247u8, 75u8, 41u8, 108u8, 108u8, 160u8, 164u8,
-                            31u8, 225u8, 13u8, 241u8, 73u8, 136u8, 147u8, 149u8, 119u8, 87u8,
-                            191u8, 80u8,
+                            20u8, 0u8, 222u8, 0u8, 73u8, 207u8, 135u8, 33u8, 219u8, 169u8, 149u8,
+                            37u8, 137u8, 29u8, 89u8, 211u8, 202u8, 255u8, 173u8, 236u8, 15u8, 54u8,
+                            5u8, 246u8, 68u8, 139u8, 91u8, 179u8, 140u8, 203u8, 161u8, 51u8,
                         ],
                     )
                 }
@@ -15894,10 +15831,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            232u8, 188u8, 42u8, 109u8, 42u8, 237u8, 157u8, 203u8, 58u8, 216u8,
-                            39u8, 134u8, 215u8, 247u8, 75u8, 41u8, 108u8, 108u8, 160u8, 164u8,
-                            31u8, 225u8, 13u8, 241u8, 73u8, 136u8, 147u8, 149u8, 119u8, 87u8,
-                            191u8, 80u8,
+                            20u8, 0u8, 222u8, 0u8, 73u8, 207u8, 135u8, 33u8, 219u8, 169u8, 149u8,
+                            37u8, 137u8, 29u8, 89u8, 211u8, 202u8, 255u8, 173u8, 236u8, 15u8, 54u8,
+                            5u8, 246u8, 68u8, 139u8, 91u8, 179u8, 140u8, 203u8, 161u8, 51u8,
                         ],
                     )
                 }
@@ -16309,12 +16245,9 @@ pub mod api {
             }
             pub mod update_from_aggregated_miner_info {
                 use super::runtime_types;
-                pub type Miner = (
-                    ::subxt::ext::subxt_core::utils::AccountId32,
-                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                        ::core::primitive::u8,
-                    >,
-                );
+                pub type Miner = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
                 pub type Online = ::core::primitive::bool;
                 pub type Available = ::core::primitive::bool;
                 pub type LastBlockProcessed = ::core::primitive::u32;
@@ -16366,17 +16299,13 @@ pub mod api {
                                 ::core::primitive::u32,
                             >,
                         >;
-                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat;
                 }
                 pub mod submitted_per_period {
                     use super::runtime_types;
                     pub type SubmittedPerPeriod = ::core::primitive::bool;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param1 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat;
                 }
                 pub mod resulting_miner_status_percentages {
                     use super::runtime_types;
@@ -16384,17 +16313,13 @@ pub mod api {
                         runtime_types::pallet_status_aggregator::ProcessStatusPercentages<
                             ::core::primitive::u32,
                         >;
-                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat;
                 }
                 pub mod resulting_miner_status {
                     use super::runtime_types;
                     pub type ResultingMinerStatus =
                         runtime_types::cyborg_primitives::oracle::ProcessStatus;
-                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat<
-                        ::subxt::ext::subxt_core::utils::AccountId32,
-                    >;
+                    pub type Param0 = runtime_types::cyborg_primitives::oracle::OracleMinerFormat;
                 }
             }
             pub struct StorageApi;
@@ -16441,10 +16366,10 @@ pub mod api {
                         "MinerStatusEntriesPerPeriod",
                         (),
                         [
-                            199u8, 184u8, 208u8, 246u8, 233u8, 66u8, 169u8, 219u8, 209u8, 190u8,
-                            136u8, 145u8, 100u8, 227u8, 226u8, 101u8, 185u8, 121u8, 242u8, 3u8,
-                            191u8, 10u8, 19u8, 32u8, 252u8, 239u8, 224u8, 2u8, 140u8, 25u8, 43u8,
-                            211u8,
+                            60u8, 37u8, 206u8, 121u8, 65u8, 203u8, 238u8, 138u8, 111u8, 189u8,
+                            103u8, 120u8, 123u8, 136u8, 188u8, 136u8, 124u8, 35u8, 250u8, 63u8,
+                            251u8, 43u8, 80u8, 83u8, 205u8, 138u8, 224u8, 38u8, 51u8, 101u8, 73u8,
+                            97u8,
                         ],
                     )
                 }
@@ -16473,10 +16398,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            199u8, 184u8, 208u8, 246u8, 233u8, 66u8, 169u8, 219u8, 209u8, 190u8,
-                            136u8, 145u8, 100u8, 227u8, 226u8, 101u8, 185u8, 121u8, 242u8, 3u8,
-                            191u8, 10u8, 19u8, 32u8, 252u8, 239u8, 224u8, 2u8, 140u8, 25u8, 43u8,
-                            211u8,
+                            60u8, 37u8, 206u8, 121u8, 65u8, 203u8, 238u8, 138u8, 111u8, 189u8,
+                            103u8, 120u8, 123u8, 136u8, 188u8, 136u8, 124u8, 35u8, 250u8, 63u8,
+                            251u8, 43u8, 80u8, 83u8, 205u8, 138u8, 224u8, 38u8, 51u8, 101u8, 73u8,
+                            97u8,
                         ],
                     )
                 }
@@ -16499,10 +16424,9 @@ pub mod api {
                         "SubmittedPerPeriod",
                         (),
                         [
-                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
-                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
-                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
-                            188u8, 2u8,
+                            242u8, 11u8, 212u8, 230u8, 38u8, 27u8, 13u8, 186u8, 160u8, 124u8,
+                            231u8, 161u8, 211u8, 73u8, 39u8, 47u8, 45u8, 252u8, 221u8, 51u8, 143u8,
+                            225u8, 117u8, 54u8, 170u8, 38u8, 199u8, 35u8, 160u8, 45u8, 137u8, 9u8,
                         ],
                     )
                 }
@@ -16530,10 +16454,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
-                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
-                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
-                            188u8, 2u8,
+                            242u8, 11u8, 212u8, 230u8, 38u8, 27u8, 13u8, 186u8, 160u8, 124u8,
+                            231u8, 161u8, 211u8, 73u8, 39u8, 47u8, 45u8, 252u8, 221u8, 51u8, 143u8,
+                            225u8, 117u8, 54u8, 170u8, 38u8, 199u8, 35u8, 160u8, 45u8, 137u8, 9u8,
                         ],
                     )
                 }
@@ -16572,10 +16495,9 @@ pub mod api {
                             ),
                         ),
                         [
-                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
-                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
-                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
-                            188u8, 2u8,
+                            242u8, 11u8, 212u8, 230u8, 38u8, 27u8, 13u8, 186u8, 160u8, 124u8,
+                            231u8, 161u8, 211u8, 73u8, 39u8, 47u8, 45u8, 252u8, 221u8, 51u8, 143u8,
+                            225u8, 117u8, 54u8, 170u8, 38u8, 199u8, 35u8, 160u8, 45u8, 137u8, 9u8,
                         ],
                     )
                 }
@@ -16599,9 +16521,10 @@ pub mod api {
                         "ResultingMinerStatusPercentages",
                         (),
                         [
-                            212u8, 231u8, 168u8, 113u8, 19u8, 16u8, 243u8, 5u8, 38u8, 162u8, 216u8,
-                            120u8, 112u8, 101u8, 109u8, 142u8, 76u8, 11u8, 198u8, 138u8, 200u8,
-                            156u8, 116u8, 67u8, 233u8, 28u8, 32u8, 74u8, 38u8, 218u8, 207u8, 59u8,
+                            152u8, 157u8, 74u8, 121u8, 205u8, 17u8, 191u8, 92u8, 181u8, 230u8,
+                            150u8, 132u8, 247u8, 181u8, 136u8, 68u8, 141u8, 97u8, 215u8, 240u8,
+                            151u8, 171u8, 25u8, 145u8, 208u8, 36u8, 16u8, 207u8, 109u8, 39u8, 62u8,
+                            118u8,
                         ],
                     )
                 }
@@ -16630,9 +16553,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            212u8, 231u8, 168u8, 113u8, 19u8, 16u8, 243u8, 5u8, 38u8, 162u8, 216u8,
-                            120u8, 112u8, 101u8, 109u8, 142u8, 76u8, 11u8, 198u8, 138u8, 200u8,
-                            156u8, 116u8, 67u8, 233u8, 28u8, 32u8, 74u8, 38u8, 218u8, 207u8, 59u8,
+                            152u8, 157u8, 74u8, 121u8, 205u8, 17u8, 191u8, 92u8, 181u8, 230u8,
+                            150u8, 132u8, 247u8, 181u8, 136u8, 68u8, 141u8, 97u8, 215u8, 240u8,
+                            151u8, 171u8, 25u8, 145u8, 208u8, 36u8, 16u8, 207u8, 109u8, 39u8, 62u8,
+                            118u8,
                         ],
                     )
                 }
@@ -16655,10 +16579,9 @@ pub mod api {
                         "ResultingMinerStatus",
                         (),
                         [
-                            101u8, 209u8, 235u8, 233u8, 95u8, 136u8, 148u8, 26u8, 214u8, 52u8,
-                            50u8, 80u8, 66u8, 115u8, 33u8, 173u8, 102u8, 82u8, 91u8, 236u8, 52u8,
-                            31u8, 238u8, 185u8, 61u8, 195u8, 105u8, 48u8, 193u8, 158u8, 61u8,
-                            100u8,
+                            43u8, 28u8, 217u8, 128u8, 30u8, 26u8, 130u8, 97u8, 240u8, 157u8, 177u8,
+                            16u8, 139u8, 78u8, 253u8, 135u8, 219u8, 54u8, 81u8, 45u8, 15u8, 90u8,
+                            34u8, 1u8, 119u8, 189u8, 107u8, 82u8, 134u8, 120u8, 219u8, 32u8,
                         ],
                     )
                 }
@@ -16686,10 +16609,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            101u8, 209u8, 235u8, 233u8, 95u8, 136u8, 148u8, 26u8, 214u8, 52u8,
-                            50u8, 80u8, 66u8, 115u8, 33u8, 173u8, 102u8, 82u8, 91u8, 236u8, 52u8,
-                            31u8, 238u8, 185u8, 61u8, 195u8, 105u8, 48u8, 193u8, 158u8, 61u8,
-                            100u8,
+                            43u8, 28u8, 217u8, 128u8, 30u8, 26u8, 130u8, 97u8, 240u8, 157u8, 177u8,
+                            16u8, 139u8, 78u8, 253u8, 135u8, 219u8, 54u8, 81u8, 45u8, 15u8, 90u8,
+                            34u8, 1u8, 119u8, 189u8, 107u8, 82u8, 134u8, 120u8, 219u8, 32u8,
                         ],
                     )
                 }
@@ -20228,9 +20150,9 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                pub enum OracleKey<_0> {
+                pub enum OracleKey {
                     #[codec(index = 0)]
-                    Miner(runtime_types::cyborg_primitives::oracle::OracleMinerFormat<_0>),
+                    Miner(runtime_types::cyborg_primitives::oracle::OracleMinerFormat),
                     #[codec(index = 1)]
                     NzkProofResult(::core::primitive::u64),
                 }
@@ -20249,13 +20171,10 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                pub struct OracleMinerFormat<_0> {
-                    pub id: (
-                        _0,
-                        runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                            ::core::primitive::u8,
-                        >,
-                    ),
+                pub struct OracleMinerFormat {
+                    pub id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                     pub miner_type: runtime_types::cyborg_primitives::miner::MinerType,
                 }
                 #[derive(
@@ -21598,9 +21517,7 @@ pub mod api {
                     #[doc = "Require authorized operator."]
                     feed_values {
                         values: runtime_types::bounded_collections::bounded_vec::BoundedVec<(
-                            runtime_types::cyborg_primitives::oracle::OracleKey<
-                                ::subxt::ext::subxt_core::utils::AccountId32,
-                            >,
+                            runtime_types::cyborg_primitives::oracle::OracleKey,
                             runtime_types::cyborg_primitives::oracle::OracleValue,
                         )>,
                     },
@@ -21651,9 +21568,7 @@ pub mod api {
                     NewFeedData {
                         sender: ::subxt::ext::subxt_core::utils::AccountId32,
                         values: ::subxt::ext::subxt_core::alloc::vec::Vec<(
-                            runtime_types::cyborg_primitives::oracle::OracleKey<
-                                ::subxt::ext::subxt_core::utils::AccountId32,
-                            >,
+                            runtime_types::cyborg_primitives::oracle::OracleKey,
                             runtime_types::cyborg_primitives::oracle::OracleValue,
                         )>,
                     },
@@ -22514,7 +22429,6 @@ pub mod api {
                     },
                     #[codec(index = 3)]
                     penalize_miner {
-                        miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
                         >,
@@ -22525,7 +22439,6 @@ pub mod api {
                     #[codec(index = 4)]
                     #[doc = "Manually suspend a miner (root only)"]
                     suspend_miner {
-                        miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
                         >,
@@ -22536,7 +22449,6 @@ pub mod api {
                     #[codec(index = 5)]
                     #[doc = "Manually ban a miner (root only)"]
                     ban_miner {
-                        miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
                         >,
@@ -22546,7 +22458,6 @@ pub mod api {
                     #[codec(index = 6)]
                     #[doc = "Lift suspension from a miner (root only)"]
                     unsuspend_miner {
-                        miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
                         >,
@@ -22693,57 +22604,42 @@ pub mod api {
                     #[codec(index = 5)]
                     #[doc = "Event emitted when a miner is penalized"]
                     MinerPenalized {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         penalty: ::core::primitive::i32,
                         reason: runtime_types::pallet_edge_connect::pallet::PenaltyReason,
                     },
                     #[codec(index = 6)]
                     #[doc = "Event emitted when a miner is suspended"]
                     MinerSuspended {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         until_block: ::core::primitive::u32,
                     },
                     #[codec(index = 7)]
                     #[doc = "Event emitted when a miner is put under review"]
                     MinerUnderReview {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
                     },
                     #[codec(index = 8)]
                     #[doc = "Event emitted when a miner is banned"]
                     MinerBanned {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
                     },
                     #[codec(index = 9)]
                     #[doc = "Event emitted when a miner is unsuspended"]
                     MinerUnsuspended {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                     },
                 }
                 #[derive(
@@ -23744,12 +23640,9 @@ pub mod api {
                     #[doc = "- `available`: A boolean indicating whether the miner is available."]
                     #[doc = "- `last_block_processed`: The block number at which the miner's status was last updated."]
                     UpdateFromAggregatedMinerInfo {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
-                                ::core::primitive::u8,
-                            >,
-                        ),
+                        miner: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         online: ::core::primitive::bool,
                         available: ::core::primitive::bool,
                         last_block_processed: ::core::primitive::u32,
@@ -23991,6 +23884,14 @@ pub mod api {
                     get_model_hash {
                         model_id: ::subxt::ext::subxt_core::alloc::vec::Vec<::core::primitive::u8>,
                     },
+                    #[codec(index = 9)]
+                    #[doc = "Reset a stuck task and its associated miner (sudo only)"]
+                    #[doc = "This allows manual intervention for tasks that are stuck in Assigned, Running, or Stopped states"]
+                    reset_task {
+                        task_id: ::core::primitive::u64,
+                        miner_type: runtime_types::cyborg_primitives::miner::MinerType,
+                        reason: runtime_types::pallet_task_management::pallet::ResetReason,
+                    },
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -24021,49 +23922,53 @@ pub mod api {
                     #[codec(index = 4)]
                     NotGatekeeper,
                     #[codec(index = 5)]
-                    TaskNotFound,
-                    #[codec(index = 6)]
                     InvalidModelId,
-                    #[codec(index = 7)]
+                    #[codec(index = 6)]
                     NotAssignedMiner,
-                    #[codec(index = 8)]
+                    #[codec(index = 7)]
                     RequireComputeHoursDeposit,
-                    #[codec(index = 9)]
+                    #[codec(index = 8)]
                     ZkFilesMissing,
+                    #[codec(index = 9)]
+                    TaskNotFound,
                     #[codec(index = 10)]
-                    UnassignedTaskId,
-                    #[codec(index = 11)]
                     InvalidTaskOwner,
-                    #[codec(index = 12)]
+                    #[codec(index = 11)]
                     TaskVerificationNotFound,
-                    #[codec(index = 13)]
+                    #[codec(index = 12)]
                     RequireAssignedTask,
-                    #[codec(index = 14)]
+                    #[codec(index = 13)]
                     RequireAssignedVerifier,
-                    #[codec(index = 15)]
+                    #[codec(index = 14)]
                     #[doc = "Account has exceeded task submission rate limit"]
                     RateLimitExceeded,
-                    #[codec(index = 16)]
+                    #[codec(index = 15)]
                     ModelAlreadyRegistered,
-                    #[codec(index = 17)]
+                    #[codec(index = 16)]
                     ModelNotFound,
-                    #[codec(index = 18)]
+                    #[codec(index = 17)]
                     TaskReceptionAlreadyConfirmed,
-                    #[codec(index = 19)]
+                    #[codec(index = 18)]
                     #[doc = "Error indicating that the miner does not exist"]
                     MinerDoesNotExist,
-                    #[codec(index = 20)]
+                    #[codec(index = 19)]
                     #[doc = "Error indicating that the miner is busy"]
                     MinerIsBusy,
-                    #[codec(index = 21)]
+                    #[codec(index = 20)]
                     #[doc = "Error indicating insufficient reputation"]
                     InsufficientReputation,
-                    #[codec(index = 22)]
+                    #[codec(index = 21)]
                     #[doc = "Error indicating that the miner is inactive"]
                     MinerIsInactive,
-                    #[codec(index = 23)]
+                    #[codec(index = 22)]
                     #[doc = "Error indicating that the miner is suspended"]
                     MinerSuspended,
+                    #[codec(index = 23)]
+                    #[doc = "Task cannot be reset in its current state"]
+                    TaskNotResettable,
+                    #[codec(index = 24)]
+                    #[doc = "Miner reset failed"]
+                    MinerResetFailed,
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -24120,6 +24025,42 @@ pub mod api {
                         ::subxt::ext::subxt_core::alloc::vec::Vec<::core::primitive::u8>,
                         ::subxt::ext::subxt_core::utils::H256,
                     ),
+                    #[codec(index = 6)]
+                    #[doc = "Event emitted when a task is manually reset by admin"]
+                    TaskManuallyReset {
+                        task_id: ::core::primitive::u64,
+                        reset_by:
+                            ::core::option::Option<::subxt::ext::subxt_core::utils::AccountId32>,
+                        previous_status: runtime_types::cyborg_primitives::task::TaskStatusType,
+                        reason: runtime_types::pallet_task_management::pallet::ResetReason,
+                    },
+                }
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                pub enum ResetReason {
+                    #[codec(index = 0)]
+                    MinerUnresponsive,
+                    #[codec(index = 1)]
+                    TaskTimeout,
+                    #[codec(index = 2)]
+                    SystemError,
+                    #[codec(index = 3)]
+                    ManualIntervention,
+                    #[codec(index = 4)]
+                    Other,
                 }
             }
         }

--- a/src/substrate_interface.rs
+++ b/src/substrate_interface.rs
@@ -71,7 +71,7 @@ pub mod api {
     pub mod runtime_apis {
         use super::root_mod;
         use super::runtime_types;
-        use subxt::ext::subxt_core::ext::codec::Encode;
+        use ::subxt::ext::subxt_core::ext::codec::Encode;
         pub struct RuntimeApi;
         impl RuntimeApi {
             pub fn aura_api(&self) -> aura_api::AuraApi {
@@ -1325,9 +1325,10 @@ pub mod api {
                         "query_call_info",
                         types::QueryCallInfo { call, len },
                         [
-                            24u8, 224u8, 140u8, 132u8, 106u8, 175u8, 118u8, 119u8, 21u8, 237u8,
-                            174u8, 141u8, 163u8, 240u8, 37u8, 209u8, 65u8, 8u8, 105u8, 57u8, 154u8,
-                            103u8, 82u8, 175u8, 138u8, 48u8, 119u8, 96u8, 249u8, 237u8, 59u8, 21u8,
+                            113u8, 113u8, 128u8, 147u8, 43u8, 188u8, 48u8, 108u8, 64u8, 244u8,
+                            181u8, 31u8, 67u8, 187u8, 147u8, 163u8, 221u8, 18u8, 69u8, 201u8,
+                            226u8, 217u8, 70u8, 177u8, 204u8, 160u8, 248u8, 181u8, 176u8, 252u8,
+                            133u8, 119u8,
                         ],
                     )
                 }
@@ -1345,10 +1346,10 @@ pub mod api {
                         "query_call_fee_details",
                         types::QueryCallFeeDetails { call, len },
                         [
-                            117u8, 36u8, 3u8, 248u8, 227u8, 199u8, 159u8, 108u8, 158u8, 254u8,
-                            197u8, 108u8, 167u8, 238u8, 160u8, 253u8, 155u8, 32u8, 211u8, 165u8,
-                            91u8, 138u8, 219u8, 41u8, 136u8, 0u8, 54u8, 140u8, 46u8, 186u8, 97u8,
-                            127u8,
+                            222u8, 243u8, 254u8, 199u8, 231u8, 133u8, 188u8, 15u8, 67u8, 171u8,
+                            15u8, 27u8, 75u8, 148u8, 213u8, 16u8, 126u8, 6u8, 59u8, 83u8, 131u8,
+                            43u8, 47u8, 64u8, 195u8, 67u8, 138u8, 153u8, 138u8, 118u8, 122u8,
+                            184u8,
                         ],
                     )
                 }
@@ -1764,10 +1765,9 @@ pub mod api {
                         "get_recent_events",
                         types::GetRecentEvents {},
                         [
-                            250u8, 220u8, 101u8, 165u8, 173u8, 17u8, 90u8, 155u8, 17u8, 129u8,
-                            210u8, 106u8, 237u8, 193u8, 193u8, 64u8, 56u8, 52u8, 110u8, 19u8, 78u8,
-                            249u8, 201u8, 133u8, 247u8, 11u8, 81u8, 246u8, 250u8, 101u8, 27u8,
-                            86u8,
+                            121u8, 211u8, 110u8, 66u8, 0u8, 93u8, 216u8, 249u8, 97u8, 124u8, 255u8,
+                            32u8, 131u8, 16u8, 93u8, 47u8, 57u8, 30u8, 57u8, 72u8, 186u8, 133u8,
+                            10u8, 86u8, 98u8, 16u8, 247u8, 152u8, 186u8, 150u8, 253u8, 253u8,
                         ],
                     )
                 }
@@ -1801,6 +1801,9 @@ pub mod api {
                 pub struct GetRecentEvents {}
             }
         }
+    }
+    pub fn view_functions() -> ViewFunctionsApi {
+        ViewFunctionsApi
     }
     pub fn custom() -> CustomValuesApi {
         CustomValuesApi
@@ -1987,6 +1990,8 @@ pub mod api {
             neuro_zk::calls::TransactionApi
         }
     }
+    pub struct ViewFunctionsApi;
+    impl ViewFunctionsApi {}
     #[doc = r" check whether the metadata provided is aligned with this statically generated code."]
     pub fn is_codegen_valid_for(metadata: &::subxt::ext::subxt_core::Metadata) -> bool {
         let runtime_metadata_hash = metadata
@@ -1996,9 +2001,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                94u8, 120u8, 61u8, 253u8, 179u8, 93u8, 194u8, 22u8, 185u8, 28u8, 227u8, 153u8,
-                81u8, 122u8, 130u8, 202u8, 234u8, 250u8, 72u8, 85u8, 12u8, 245u8, 92u8, 78u8, 83u8,
-                224u8, 189u8, 217u8, 82u8, 23u8, 223u8, 181u8,
+                86u8, 8u8, 38u8, 194u8, 128u8, 60u8, 118u8, 91u8, 121u8, 54u8, 75u8, 133u8, 248u8,
+                219u8, 220u8, 10u8, 214u8, 4u8, 241u8, 208u8, 250u8, 44u8, 195u8, 35u8, 164u8,
+                192u8, 160u8, 153u8, 237u8, 140u8, 241u8, 6u8,
             ]
     }
     pub mod system {
@@ -3187,9 +3192,10 @@ pub mod api {
                         "Events",
                         (),
                         [
-                            126u8, 162u8, 156u8, 16u8, 233u8, 82u8, 177u8, 191u8, 249u8, 29u8,
-                            155u8, 31u8, 173u8, 171u8, 67u8, 247u8, 121u8, 58u8, 97u8, 199u8, 0u8,
-                            193u8, 41u8, 117u8, 223u8, 211u8, 119u8, 93u8, 90u8, 86u8, 191u8, 42u8,
+                            20u8, 61u8, 21u8, 15u8, 160u8, 161u8, 76u8, 117u8, 30u8, 70u8, 169u8,
+                            182u8, 112u8, 144u8, 153u8, 211u8, 223u8, 0u8, 163u8, 246u8, 103u8,
+                            40u8, 246u8, 179u8, 197u8, 162u8, 183u8, 29u8, 193u8, 138u8, 230u8,
+                            15u8,
                         ],
                     )
                 }
@@ -6691,9 +6697,9 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            54u8, 119u8, 178u8, 52u8, 120u8, 168u8, 136u8, 250u8, 116u8, 253u8,
-                            109u8, 187u8, 72u8, 99u8, 166u8, 238u8, 97u8, 194u8, 12u8, 99u8, 40u8,
-                            132u8, 131u8, 253u8, 96u8, 213u8, 5u8, 27u8, 26u8, 1u8, 90u8, 235u8,
+                            91u8, 241u8, 38u8, 199u8, 40u8, 62u8, 152u8, 67u8, 1u8, 23u8, 49u8,
+                            59u8, 99u8, 227u8, 161u8, 89u8, 35u8, 196u8, 244u8, 109u8, 19u8, 137u8,
+                            147u8, 134u8, 75u8, 85u8, 172u8, 53u8, 231u8, 179u8, 161u8, 154u8,
                         ],
                     )
                 }
@@ -6716,10 +6722,9 @@ pub mod api {
                             weight,
                         },
                         [
-                            40u8, 168u8, 25u8, 228u8, 205u8, 187u8, 227u8, 229u8, 159u8, 46u8,
-                            60u8, 93u8, 67u8, 108u8, 105u8, 89u8, 29u8, 245u8, 161u8, 144u8, 79u8,
-                            45u8, 177u8, 200u8, 66u8, 186u8, 163u8, 243u8, 176u8, 83u8, 113u8,
-                            245u8,
+                            42u8, 185u8, 32u8, 194u8, 117u8, 190u8, 217u8, 255u8, 203u8, 149u8,
+                            158u8, 251u8, 158u8, 231u8, 58u8, 93u8, 79u8, 149u8, 140u8, 120u8, 9u8,
+                            37u8, 179u8, 66u8, 205u8, 63u8, 85u8, 215u8, 98u8, 62u8, 143u8, 220u8,
                         ],
                     )
                 }
@@ -6759,10 +6764,10 @@ pub mod api {
                             call: ::subxt::ext::subxt_core::alloc::boxed::Box::new(call),
                         },
                         [
-                            236u8, 107u8, 238u8, 113u8, 251u8, 214u8, 55u8, 168u8, 216u8, 159u8,
-                            145u8, 89u8, 144u8, 174u8, 199u8, 164u8, 234u8, 159u8, 102u8, 2u8,
-                            111u8, 72u8, 146u8, 163u8, 98u8, 58u8, 76u8, 114u8, 162u8, 135u8,
-                            194u8, 47u8,
+                            183u8, 228u8, 246u8, 141u8, 61u8, 207u8, 160u8, 82u8, 72u8, 47u8,
+                            157u8, 234u8, 36u8, 148u8, 206u8, 145u8, 3u8, 194u8, 206u8, 168u8,
+                            35u8, 255u8, 39u8, 131u8, 199u8, 190u8, 30u8, 218u8, 6u8, 115u8, 83u8,
+                            150u8,
                         ],
                     )
                 }
@@ -13171,10 +13176,10 @@ pub mod api {
                         "feed_values",
                         types::FeedValues { values },
                         [
-                            241u8, 212u8, 123u8, 247u8, 88u8, 30u8, 55u8, 197u8, 232u8, 246u8,
-                            134u8, 202u8, 34u8, 87u8, 144u8, 140u8, 227u8, 122u8, 188u8, 33u8,
-                            228u8, 31u8, 145u8, 27u8, 3u8, 204u8, 153u8, 6u8, 243u8, 6u8, 184u8,
-                            248u8,
+                            222u8, 59u8, 219u8, 184u8, 217u8, 219u8, 61u8, 245u8, 110u8, 11u8,
+                            136u8, 176u8, 5u8, 19u8, 20u8, 17u8, 57u8, 52u8, 205u8, 227u8, 54u8,
+                            213u8, 138u8, 142u8, 122u8, 4u8, 219u8, 237u8, 96u8, 108u8, 212u8,
+                            131u8,
                         ],
                     )
                 }
@@ -13264,10 +13269,9 @@ pub mod api {
                         "RawValues",
                         (),
                         [
-                            217u8, 3u8, 237u8, 202u8, 67u8, 123u8, 247u8, 255u8, 221u8, 38u8,
-                            132u8, 248u8, 135u8, 168u8, 56u8, 157u8, 202u8, 101u8, 171u8, 204u8,
-                            209u8, 195u8, 76u8, 168u8, 31u8, 30u8, 191u8, 64u8, 49u8, 248u8, 26u8,
-                            228u8,
+                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
+                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
+                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
                         ],
                     )
                 }
@@ -13291,10 +13295,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            217u8, 3u8, 237u8, 202u8, 67u8, 123u8, 247u8, 255u8, 221u8, 38u8,
-                            132u8, 248u8, 135u8, 168u8, 56u8, 157u8, 202u8, 101u8, 171u8, 204u8,
-                            209u8, 195u8, 76u8, 168u8, 31u8, 30u8, 191u8, 64u8, 49u8, 248u8, 26u8,
-                            228u8,
+                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
+                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
+                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
                         ],
                     )
                 }
@@ -13329,10 +13332,9 @@ pub mod api {
                             ),
                         ),
                         [
-                            217u8, 3u8, 237u8, 202u8, 67u8, 123u8, 247u8, 255u8, 221u8, 38u8,
-                            132u8, 248u8, 135u8, 168u8, 56u8, 157u8, 202u8, 101u8, 171u8, 204u8,
-                            209u8, 195u8, 76u8, 168u8, 31u8, 30u8, 191u8, 64u8, 49u8, 248u8, 26u8,
-                            228u8,
+                            164u8, 85u8, 48u8, 25u8, 151u8, 96u8, 120u8, 52u8, 158u8, 107u8, 27u8,
+                            224u8, 79u8, 207u8, 200u8, 200u8, 213u8, 217u8, 120u8, 150u8, 42u8,
+                            224u8, 79u8, 38u8, 119u8, 191u8, 195u8, 176u8, 9u8, 45u8, 110u8, 120u8,
                         ],
                     )
                 }
@@ -13351,10 +13353,10 @@ pub mod api {
                         "Values",
                         (),
                         [
-                            124u8, 141u8, 209u8, 166u8, 21u8, 56u8, 218u8, 39u8, 229u8, 95u8,
-                            245u8, 96u8, 97u8, 99u8, 161u8, 87u8, 44u8, 166u8, 93u8, 140u8, 251u8,
-                            123u8, 63u8, 107u8, 208u8, 167u8, 179u8, 159u8, 240u8, 52u8, 159u8,
-                            165u8,
+                            134u8, 60u8, 119u8, 192u8, 231u8, 75u8, 113u8, 140u8, 58u8, 158u8,
+                            93u8, 229u8, 132u8, 108u8, 122u8, 143u8, 49u8, 192u8, 237u8, 175u8,
+                            206u8, 82u8, 15u8, 15u8, 34u8, 91u8, 118u8, 78u8, 14u8, 219u8, 153u8,
+                            236u8,
                         ],
                     )
                 }
@@ -13378,10 +13380,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            124u8, 141u8, 209u8, 166u8, 21u8, 56u8, 218u8, 39u8, 229u8, 95u8,
-                            245u8, 96u8, 97u8, 99u8, 161u8, 87u8, 44u8, 166u8, 93u8, 140u8, 251u8,
-                            123u8, 63u8, 107u8, 208u8, 167u8, 179u8, 159u8, 240u8, 52u8, 159u8,
-                            165u8,
+                            134u8, 60u8, 119u8, 192u8, 231u8, 75u8, 113u8, 140u8, 58u8, 158u8,
+                            93u8, 229u8, 132u8, 108u8, 122u8, 143u8, 49u8, 192u8, 237u8, 175u8,
+                            206u8, 82u8, 15u8, 15u8, 34u8, 91u8, 118u8, 78u8, 14u8, 219u8, 153u8,
+                            236u8,
                         ],
                     )
                 }
@@ -14053,6 +14055,7 @@ pub mod api {
                 #[doc = "Registers a Miner with either a domain and initialize it with an inactive status."]
                 pub struct RegisterMiner {
                     pub miner_type: register_miner::MinerType,
+                    pub miner_uuid: register_miner::MinerUuid,
                     pub domain: register_miner::Domain,
                     pub latitude: register_miner::Latitude,
                     pub longitude: register_miner::Longitude,
@@ -14063,6 +14066,8 @@ pub mod api {
                 pub mod register_miner {
                     use super::runtime_types;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
+                    pub type MinerUuid =
+                        ::subxt::ext::subxt_core::alloc::vec::Vec<::core::primitive::u8>;
                     pub type Domain = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                         ::core::primitive::u8,
                     >;
@@ -14099,7 +14104,9 @@ pub mod api {
                 pub mod remove_miner {
                     use super::runtime_types;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                 }
                 impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for RemoveMiner {
                     const PALLET: &'static str = "EdgeConnect";
@@ -14120,21 +14127,25 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                #[doc = "Switches the visibility of a miner between active and inactive."]
-                pub struct ToggleMinerVisibility {
-                    pub miner_type: toggle_miner_visibility::MinerType,
-                    pub miner_id: toggle_miner_visibility::MinerId,
-                    pub visibility: toggle_miner_visibility::Visibility,
+                #[doc = "Updates the oracle status (callable by oracle feeder)"]
+                pub struct UpdateOracleStatus {
+                    pub miner_owner: update_oracle_status::MinerOwner,
+                    pub miner_id: update_oracle_status::MinerId,
+                    pub miner_type: update_oracle_status::MinerType,
+                    pub online: update_oracle_status::Online,
                 }
-                pub mod toggle_miner_visibility {
+                pub mod update_oracle_status {
                     use super::runtime_types;
+                    pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
-                    pub type MinerId = ::core::primitive::u64;
-                    pub type Visibility = ::core::primitive::bool;
+                    pub type Online = ::core::primitive::bool;
                 }
-                impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for ToggleMinerVisibility {
+                impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for UpdateOracleStatus {
                     const PALLET: &'static str = "EdgeConnect";
-                    const CALL: &'static str = "toggle_miner_visibility";
+                    const CALL: &'static str = "update_oracle_status";
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -14161,7 +14172,9 @@ pub mod api {
                 pub mod penalize_miner {
                     use super::runtime_types;
                     pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
                     pub type Penalty = ::core::primitive::i32;
                     pub type Reason = runtime_types::pallet_edge_connect::pallet::PenaltyReason;
@@ -14196,7 +14209,9 @@ pub mod api {
                 pub mod suspend_miner {
                     use super::runtime_types;
                     pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
                     pub type Blocks = ::core::primitive::u32;
                     pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
@@ -14230,7 +14245,9 @@ pub mod api {
                 pub mod ban_miner {
                     use super::runtime_types;
                     pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
                     pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
                 }
@@ -14262,12 +14279,47 @@ pub mod api {
                 pub mod unsuspend_miner {
                     use super::runtime_types;
                     pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
                 }
                 impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for UnsuspendMiner {
                     const PALLET: &'static str = "EdgeConnect";
                     const CALL: &'static str = "unsuspend_miner";
+                }
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                #[doc = "Updates the operational status (callable by miner itself)"]
+                pub struct UpdateOperationalStatus {
+                    pub miner_type: update_operational_status::MinerType,
+                    pub miner_id: update_operational_status::MinerId,
+                    pub status: update_operational_status::Status,
+                }
+                pub mod update_operational_status {
+                    use super::runtime_types;
+                    pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
+                    pub type Status = runtime_types::cyborg_primitives::miner::OperationalStatus;
+                }
+                impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for UpdateOperationalStatus {
+                    const PALLET: &'static str = "EdgeConnect";
+                    const CALL: &'static str = "update_operational_status";
                 }
             }
             pub struct TransactionApi;
@@ -14276,6 +14328,7 @@ pub mod api {
                 pub fn register_miner(
                     &self,
                     miner_type: types::register_miner::MinerType,
+                    miner_uuid: types::register_miner::MinerUuid,
                     domain: types::register_miner::Domain,
                     latitude: types::register_miner::Latitude,
                     longitude: types::register_miner::Longitude,
@@ -14289,6 +14342,7 @@ pub mod api {
                         "register_miner",
                         types::RegisterMiner {
                             miner_type,
+                            miner_uuid,
                             domain,
                             latitude,
                             longitude,
@@ -14297,9 +14351,10 @@ pub mod api {
                             cpu,
                         },
                         [
-                            209u8, 147u8, 114u8, 64u8, 212u8, 218u8, 5u8, 191u8, 245u8, 86u8, 19u8,
-                            4u8, 27u8, 188u8, 24u8, 229u8, 175u8, 174u8, 157u8, 153u8, 228u8, 72u8,
-                            121u8, 141u8, 45u8, 217u8, 137u8, 160u8, 130u8, 220u8, 44u8, 109u8,
+                            246u8, 75u8, 242u8, 38u8, 7u8, 136u8, 188u8, 33u8, 145u8, 19u8, 101u8,
+                            14u8, 204u8, 6u8, 205u8, 195u8, 133u8, 230u8, 101u8, 222u8, 174u8,
+                            233u8, 79u8, 252u8, 231u8, 130u8, 228u8, 24u8, 134u8, 192u8, 155u8,
+                            122u8,
                         ],
                     )
                 }
@@ -14318,34 +14373,35 @@ pub mod api {
                             miner_id,
                         },
                         [
-                            187u8, 79u8, 228u8, 244u8, 52u8, 42u8, 121u8, 205u8, 135u8, 17u8,
-                            106u8, 223u8, 202u8, 143u8, 201u8, 25u8, 8u8, 70u8, 182u8, 30u8, 7u8,
-                            175u8, 34u8, 193u8, 230u8, 174u8, 255u8, 165u8, 69u8, 9u8, 68u8, 18u8,
+                            161u8, 159u8, 17u8, 105u8, 142u8, 80u8, 231u8, 78u8, 54u8, 182u8, 60u8,
+                            242u8, 185u8, 31u8, 242u8, 115u8, 132u8, 43u8, 96u8, 211u8, 195u8,
+                            92u8, 219u8, 180u8, 33u8, 71u8, 149u8, 192u8, 25u8, 49u8, 132u8, 180u8,
                         ],
                     )
                 }
-                #[doc = "Switches the visibility of a miner between active and inactive."]
-                pub fn toggle_miner_visibility(
+                #[doc = "Updates the oracle status (callable by oracle feeder)"]
+                pub fn update_oracle_status(
                     &self,
-                    miner_type: types::toggle_miner_visibility::MinerType,
-                    miner_id: types::toggle_miner_visibility::MinerId,
-                    visibility: types::toggle_miner_visibility::Visibility,
-                ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<
-                    types::ToggleMinerVisibility,
-                > {
+                    miner_owner: types::update_oracle_status::MinerOwner,
+                    miner_id: types::update_oracle_status::MinerId,
+                    miner_type: types::update_oracle_status::MinerType,
+                    online: types::update_oracle_status::Online,
+                ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<types::UpdateOracleStatus>
+                {
                     ::subxt::ext::subxt_core::tx::payload::StaticPayload::new_static(
                         "EdgeConnect",
-                        "toggle_miner_visibility",
-                        types::ToggleMinerVisibility {
-                            miner_type,
+                        "update_oracle_status",
+                        types::UpdateOracleStatus {
+                            miner_owner,
                             miner_id,
-                            visibility,
+                            miner_type,
+                            online,
                         },
                         [
-                            3u8, 41u8, 146u8, 94u8, 198u8, 20u8, 130u8, 6u8, 169u8, 188u8, 173u8,
-                            73u8, 57u8, 249u8, 205u8, 202u8, 203u8, 58u8, 114u8, 178u8, 153u8,
-                            164u8, 23u8, 154u8, 215u8, 190u8, 202u8, 62u8, 97u8, 110u8, 33u8,
-                            219u8,
+                            123u8, 248u8, 193u8, 62u8, 44u8, 182u8, 155u8, 61u8, 114u8, 242u8,
+                            63u8, 55u8, 227u8, 253u8, 75u8, 168u8, 120u8, 123u8, 179u8, 153u8,
+                            206u8, 227u8, 4u8, 246u8, 122u8, 102u8, 171u8, 173u8, 167u8, 139u8,
+                            255u8, 101u8,
                         ],
                     )
                 }
@@ -14369,9 +14425,10 @@ pub mod api {
                             reason,
                         },
                         [
-                            40u8, 73u8, 29u8, 185u8, 189u8, 110u8, 207u8, 12u8, 83u8, 101u8, 100u8,
-                            105u8, 129u8, 95u8, 59u8, 28u8, 164u8, 140u8, 133u8, 112u8, 247u8,
-                            21u8, 46u8, 22u8, 239u8, 147u8, 185u8, 159u8, 66u8, 226u8, 183u8, 81u8,
+                            186u8, 124u8, 226u8, 63u8, 56u8, 203u8, 187u8, 178u8, 195u8, 95u8,
+                            112u8, 227u8, 237u8, 181u8, 102u8, 73u8, 166u8, 215u8, 252u8, 15u8,
+                            210u8, 50u8, 58u8, 156u8, 216u8, 120u8, 160u8, 14u8, 227u8, 253u8,
+                            112u8, 203u8,
                         ],
                     )
                 }
@@ -14396,10 +14453,9 @@ pub mod api {
                             reason,
                         },
                         [
-                            41u8, 114u8, 24u8, 225u8, 12u8, 249u8, 191u8, 176u8, 183u8, 158u8,
-                            113u8, 82u8, 130u8, 236u8, 155u8, 38u8, 127u8, 178u8, 232u8, 62u8,
-                            212u8, 173u8, 105u8, 43u8, 59u8, 146u8, 253u8, 65u8, 131u8, 175u8,
-                            249u8, 134u8,
+                            116u8, 15u8, 51u8, 159u8, 199u8, 117u8, 39u8, 137u8, 28u8, 55u8, 147u8,
+                            237u8, 207u8, 59u8, 64u8, 131u8, 100u8, 142u8, 138u8, 209u8, 247u8,
+                            122u8, 219u8, 223u8, 16u8, 140u8, 98u8, 35u8, 73u8, 24u8, 201u8, 238u8,
                         ],
                     )
                 }
@@ -14422,9 +14478,9 @@ pub mod api {
                             reason,
                         },
                         [
-                            95u8, 81u8, 244u8, 73u8, 124u8, 205u8, 125u8, 25u8, 204u8, 191u8, 80u8,
-                            212u8, 171u8, 57u8, 143u8, 55u8, 3u8, 210u8, 144u8, 247u8, 129u8,
-                            211u8, 187u8, 65u8, 227u8, 205u8, 27u8, 42u8, 50u8, 20u8, 244u8, 157u8,
+                            57u8, 221u8, 144u8, 19u8, 2u8, 94u8, 161u8, 151u8, 81u8, 68u8, 175u8,
+                            123u8, 252u8, 132u8, 181u8, 246u8, 63u8, 23u8, 21u8, 118u8, 79u8, 53u8,
+                            85u8, 235u8, 199u8, 154u8, 217u8, 212u8, 16u8, 205u8, 8u8, 80u8,
                         ],
                     )
                 }
@@ -14445,9 +14501,33 @@ pub mod api {
                             miner_type,
                         },
                         [
-                            206u8, 191u8, 168u8, 28u8, 142u8, 187u8, 38u8, 49u8, 65u8, 243u8, 12u8,
-                            220u8, 150u8, 66u8, 254u8, 151u8, 246u8, 90u8, 116u8, 40u8, 145u8,
-                            82u8, 208u8, 111u8, 190u8, 45u8, 89u8, 82u8, 211u8, 136u8, 100u8, 15u8,
+                            53u8, 169u8, 208u8, 100u8, 14u8, 117u8, 137u8, 147u8, 233u8, 80u8,
+                            14u8, 41u8, 36u8, 238u8, 173u8, 19u8, 55u8, 124u8, 133u8, 97u8, 170u8,
+                            31u8, 224u8, 12u8, 166u8, 230u8, 88u8, 82u8, 30u8, 199u8, 25u8, 191u8,
+                        ],
+                    )
+                }
+                #[doc = "Updates the operational status (callable by miner itself)"]
+                pub fn update_operational_status(
+                    &self,
+                    miner_type: types::update_operational_status::MinerType,
+                    miner_id: types::update_operational_status::MinerId,
+                    status: types::update_operational_status::Status,
+                ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<
+                    types::UpdateOperationalStatus,
+                > {
+                    ::subxt::ext::subxt_core::tx::payload::StaticPayload::new_static(
+                        "EdgeConnect",
+                        "update_operational_status",
+                        types::UpdateOperationalStatus {
+                            miner_type,
+                            miner_id,
+                            status,
+                        },
+                        [
+                            81u8, 60u8, 39u8, 51u8, 90u8, 231u8, 21u8, 240u8, 216u8, 195u8, 104u8,
+                            28u8, 147u8, 91u8, 111u8, 26u8, 29u8, 108u8, 140u8, 187u8, 167u8,
+                            177u8, 9u8, 29u8, 145u8, 21u8, 128u8, 243u8, 68u8, 176u8, 198u8, 122u8,
                         ],
                     )
                 }
@@ -14484,7 +14564,9 @@ pub mod api {
                 pub type Creator = ::subxt::ext::subxt_core::utils::AccountId32;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Domain = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                     ::core::primitive::u8,
@@ -14519,7 +14601,9 @@ pub mod api {
                 pub type Creator = ::subxt::ext::subxt_core::utils::AccountId32;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Domain = runtime_types::bounded_collections::bounded_vec::BoundedVec<
                     ::core::primitive::u8,
@@ -14551,7 +14635,9 @@ pub mod api {
             pub mod miner_removed {
                 use super::runtime_types;
                 pub type Creator = ::subxt::ext::subxt_core::utils::AccountId32;
-                pub type MinerId = ::core::primitive::u64;
+                pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                    ::core::primitive::u8,
+                >;
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerRemoved {
                 const PALLET: &'static str = "EdgeConnect";
@@ -14568,25 +14654,52 @@ pub mod api {
             #[codec(dumb_trait_bound)]
             #[decode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode")]
             #[encode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode")]
-            #[doc = "Event emitted when a miner's status is updated (e.g., toggling visibility)."]
-            #[doc = ""]
-            #[doc = "- `creator`: The account ID of the miner's creator."]
-            #[doc = "- `miner_id`: The ID of the miner whose status was updated."]
-            #[doc = "- `miner_status`: The new status of the miner, either active or inactive."]
-            pub struct MinerStatusUpdated {
-                pub creator: miner_status_updated::Creator,
-                pub miner_id: miner_status_updated::MinerId,
-                pub miner_status: miner_status_updated::MinerStatus,
+            pub struct OracleStatusUpdated {
+                pub worker: oracle_status_updated::Worker,
+                pub online: oracle_status_updated::Online,
             }
-            pub mod miner_status_updated {
+            pub mod oracle_status_updated {
                 use super::runtime_types;
-                pub type Creator = ::subxt::ext::subxt_core::utils::AccountId32;
-                pub type MinerId = ::core::primitive::u64;
-                pub type MinerStatus = runtime_types::cyborg_primitives::miner::MinerStatusType;
+                pub type Worker = (
+                    ::subxt::ext::subxt_core::utils::AccountId32,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
+                );
+                pub type Online = ::core::primitive::bool;
             }
-            impl ::subxt::ext::subxt_core::events::StaticEvent for MinerStatusUpdated {
+            impl ::subxt::ext::subxt_core::events::StaticEvent for OracleStatusUpdated {
                 const PALLET: &'static str = "EdgeConnect";
-                const EVENT: &'static str = "MinerStatusUpdated";
+                const EVENT: &'static str = "OracleStatusUpdated";
+            }
+            #[derive(
+                :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                Debug,
+            )]
+            # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+            #[codec(dumb_trait_bound)]
+            #[decode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode")]
+            #[encode_as_type(crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode")]
+            pub struct OperationalStatusUpdated {
+                pub worker: operational_status_updated::Worker,
+                pub status: operational_status_updated::Status,
+            }
+            pub mod operational_status_updated {
+                use super::runtime_types;
+                pub type Worker = (
+                    ::subxt::ext::subxt_core::utils::AccountId32,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
+                );
+                pub type Status = runtime_types::cyborg_primitives::miner::OperationalStatus;
+            }
+            impl ::subxt::ext::subxt_core::events::StaticEvent for OperationalStatusUpdated {
+                const PALLET: &'static str = "EdgeConnect";
+                const EVENT: &'static str = "OperationalStatusUpdated";
             }
             #[derive(
                 :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -14609,7 +14722,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Penalty = ::core::primitive::i32;
                 pub type Reason = runtime_types::pallet_edge_connect::pallet::PenaltyReason;
@@ -14638,7 +14753,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type UntilBlock = ::core::primitive::u32;
             }
@@ -14666,7 +14783,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
             }
@@ -14694,7 +14813,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Reason = runtime_types::cyborg_primitives::miner::SuspensionReason;
             }
@@ -14721,7 +14842,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
             }
             impl ::subxt::ext::subxt_core::events::StaticEvent for MinerUnsuspended {
@@ -14735,7 +14858,10 @@ pub mod api {
                 use super::runtime_types;
                 pub mod account_miners {
                     use super::runtime_types;
-                    pub type AccountMiners = ::core::primitive::u64;
+                    pub type AccountMiners =
+                        runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
                 }
                 pub mod suspended_miners {
@@ -14745,7 +14871,9 @@ pub mod api {
                         runtime_types::cyborg_primitives::miner::SuspensionReason,
                     );
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = ::core::primitive::u64;
+                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                 }
                 pub mod cloud_miners {
                     use super::runtime_types;
@@ -14755,7 +14883,9 @@ pub mod api {
                         ::core::primitive::u64,
                     >;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = ::core::primitive::u64;
+                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                 }
                 pub mod edge_miners {
                     use super::runtime_types;
@@ -14765,7 +14895,9 @@ pub mod api {
                         ::core::primitive::u64,
                     >;
                     pub type Param0 = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type Param1 = ::core::primitive::u64;
+                    pub type Param1 = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                 }
             }
             pub struct StorageApi;
@@ -14786,10 +14918,9 @@ pub mod api {
                         "AccountMiners",
                         (),
                         [
-                            139u8, 52u8, 43u8, 217u8, 55u8, 47u8, 184u8, 254u8, 109u8, 226u8,
-                            208u8, 12u8, 130u8, 215u8, 191u8, 2u8, 206u8, 9u8, 96u8, 83u8, 164u8,
-                            119u8, 241u8, 128u8, 224u8, 0u8, 25u8, 127u8, 157u8, 222u8, 195u8,
-                            198u8,
+                            158u8, 52u8, 82u8, 57u8, 152u8, 108u8, 177u8, 68u8, 231u8, 244u8, 24u8,
+                            83u8, 57u8, 2u8, 9u8, 27u8, 48u8, 176u8, 14u8, 69u8, 177u8, 32u8,
+                            149u8, 132u8, 161u8, 194u8, 77u8, 74u8, 165u8, 153u8, 7u8, 110u8,
                         ],
                     )
                 }
@@ -14814,10 +14945,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            139u8, 52u8, 43u8, 217u8, 55u8, 47u8, 184u8, 254u8, 109u8, 226u8,
-                            208u8, 12u8, 130u8, 215u8, 191u8, 2u8, 206u8, 9u8, 96u8, 83u8, 164u8,
-                            119u8, 241u8, 128u8, 224u8, 0u8, 25u8, 127u8, 157u8, 222u8, 195u8,
-                            198u8,
+                            158u8, 52u8, 82u8, 57u8, 152u8, 108u8, 177u8, 68u8, 231u8, 244u8, 24u8,
+                            83u8, 57u8, 2u8, 9u8, 27u8, 48u8, 176u8, 14u8, 69u8, 177u8, 32u8,
+                            149u8, 132u8, 161u8, 194u8, 77u8, 74u8, 165u8, 153u8, 7u8, 110u8,
                         ],
                     )
                 }
@@ -14835,9 +14965,9 @@ pub mod api {
                         "SuspendedMiners",
                         (),
                         [
-                            123u8, 54u8, 26u8, 167u8, 58u8, 35u8, 129u8, 177u8, 92u8, 223u8, 210u8,
-                            158u8, 216u8, 217u8, 13u8, 250u8, 133u8, 43u8, 48u8, 25u8, 25u8, 170u8,
-                            146u8, 127u8, 74u8, 146u8, 15u8, 99u8, 191u8, 241u8, 153u8, 164u8,
+                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
+                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
+                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
                         ],
                     )
                 }
@@ -14860,9 +14990,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            123u8, 54u8, 26u8, 167u8, 58u8, 35u8, 129u8, 177u8, 92u8, 223u8, 210u8,
-                            158u8, 216u8, 217u8, 13u8, 250u8, 133u8, 43u8, 48u8, 25u8, 25u8, 170u8,
-                            146u8, 127u8, 74u8, 146u8, 15u8, 99u8, 191u8, 241u8, 153u8, 164u8,
+                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
+                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
+                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
                         ],
                     )
                 }
@@ -14896,9 +15026,9 @@ pub mod api {
                             ),
                         ),
                         [
-                            123u8, 54u8, 26u8, 167u8, 58u8, 35u8, 129u8, 177u8, 92u8, 223u8, 210u8,
-                            158u8, 216u8, 217u8, 13u8, 250u8, 133u8, 43u8, 48u8, 25u8, 25u8, 170u8,
-                            146u8, 127u8, 74u8, 146u8, 15u8, 99u8, 191u8, 241u8, 153u8, 164u8,
+                            20u8, 54u8, 143u8, 254u8, 30u8, 9u8, 68u8, 52u8, 154u8, 200u8, 207u8,
+                            98u8, 117u8, 156u8, 8u8, 33u8, 118u8, 102u8, 66u8, 29u8, 219u8, 181u8,
+                            64u8, 150u8, 229u8, 239u8, 58u8, 219u8, 164u8, 137u8, 101u8, 45u8,
                         ],
                     )
                 }
@@ -14917,9 +15047,9 @@ pub mod api {
                         "CloudMiners",
                         (),
                         [
-                            249u8, 161u8, 15u8, 129u8, 131u8, 181u8, 218u8, 20u8, 245u8, 187u8,
-                            44u8, 78u8, 194u8, 43u8, 173u8, 34u8, 243u8, 183u8, 58u8, 126u8, 167u8,
-                            230u8, 122u8, 59u8, 51u8, 64u8, 177u8, 49u8, 128u8, 112u8, 80u8, 221u8,
+                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
+                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
+                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
                         ],
                     )
                 }
@@ -14943,9 +15073,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            249u8, 161u8, 15u8, 129u8, 131u8, 181u8, 218u8, 20u8, 245u8, 187u8,
-                            44u8, 78u8, 194u8, 43u8, 173u8, 34u8, 243u8, 183u8, 58u8, 126u8, 167u8,
-                            230u8, 122u8, 59u8, 51u8, 64u8, 177u8, 49u8, 128u8, 112u8, 80u8, 221u8,
+                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
+                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
+                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
                         ],
                     )
                 }
@@ -14980,9 +15110,9 @@ pub mod api {
                             ),
                         ),
                         [
-                            249u8, 161u8, 15u8, 129u8, 131u8, 181u8, 218u8, 20u8, 245u8, 187u8,
-                            44u8, 78u8, 194u8, 43u8, 173u8, 34u8, 243u8, 183u8, 58u8, 126u8, 167u8,
-                            230u8, 122u8, 59u8, 51u8, 64u8, 177u8, 49u8, 128u8, 112u8, 80u8, 221u8,
+                            104u8, 11u8, 201u8, 94u8, 95u8, 211u8, 107u8, 235u8, 62u8, 21u8, 31u8,
+                            144u8, 108u8, 189u8, 166u8, 156u8, 233u8, 231u8, 165u8, 8u8, 238u8,
+                            8u8, 61u8, 211u8, 191u8, 79u8, 58u8, 210u8, 84u8, 188u8, 155u8, 123u8,
                         ],
                     )
                 }
@@ -15001,9 +15131,9 @@ pub mod api {
                         "EdgeMiners",
                         (),
                         [
-                            199u8, 9u8, 109u8, 186u8, 144u8, 48u8, 4u8, 187u8, 32u8, 142u8, 74u8,
-                            196u8, 137u8, 12u8, 7u8, 228u8, 49u8, 219u8, 205u8, 60u8, 253u8, 55u8,
-                            59u8, 142u8, 39u8, 121u8, 196u8, 63u8, 152u8, 37u8, 112u8, 203u8,
+                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
+                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
+                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
                         ],
                     )
                 }
@@ -15027,9 +15157,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            199u8, 9u8, 109u8, 186u8, 144u8, 48u8, 4u8, 187u8, 32u8, 142u8, 74u8,
-                            196u8, 137u8, 12u8, 7u8, 228u8, 49u8, 219u8, 205u8, 60u8, 253u8, 55u8,
-                            59u8, 142u8, 39u8, 121u8, 196u8, 63u8, 152u8, 37u8, 112u8, 203u8,
+                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
+                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
+                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
                         ],
                     )
                 }
@@ -15064,9 +15194,9 @@ pub mod api {
                             ),
                         ),
                         [
-                            199u8, 9u8, 109u8, 186u8, 144u8, 48u8, 4u8, 187u8, 32u8, 142u8, 74u8,
-                            196u8, 137u8, 12u8, 7u8, 228u8, 49u8, 219u8, 205u8, 60u8, 253u8, 55u8,
-                            59u8, 142u8, 39u8, 121u8, 196u8, 63u8, 152u8, 37u8, 112u8, 203u8,
+                            41u8, 40u8, 2u8, 61u8, 109u8, 74u8, 187u8, 142u8, 173u8, 224u8, 26u8,
+                            42u8, 42u8, 7u8, 46u8, 176u8, 49u8, 12u8, 210u8, 238u8, 203u8, 126u8,
+                            222u8, 25u8, 116u8, 177u8, 120u8, 64u8, 108u8, 172u8, 118u8, 186u8,
                         ],
                     )
                 }
@@ -15114,7 +15244,9 @@ pub mod api {
                     use super::runtime_types;
                     pub type TaskKind = runtime_types::cyborg_primitives::task::TaskSubmissionData;
                     pub type MinerOwner = ::subxt::ext::subxt_core::utils::AccountId32;
-                    pub type MinerId = ::core::primitive::u64;
+                    pub type MinerId = runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >;
                     pub type ComputeHoursDeposit = ::core::option::Option<::core::primitive::u32>;
                 }
                 impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for TaskScheduler {
@@ -15199,10 +15331,12 @@ pub mod api {
                 #[doc = "Stopped to vacated"]
                 pub struct ConfirmMinerVacation {
                     pub task_id: confirm_miner_vacation::TaskId,
+                    pub miner_type: confirm_miner_vacation::MinerType,
                 }
                 pub mod confirm_miner_vacation {
                     use super::runtime_types;
                     pub type TaskId = ::core::primitive::u64;
+                    pub type MinerType = runtime_types::cyborg_primitives::miner::MinerType;
                 }
                 impl ::subxt::ext::subxt_core::blocks::StaticExtrinsic for ConfirmMinerVacation {
                     const PALLET: &'static str = "TaskManagement";
@@ -15313,9 +15447,9 @@ pub mod api {
                             compute_hours_deposit,
                         },
                         [
-                            69u8, 26u8, 211u8, 160u8, 91u8, 103u8, 203u8, 2u8, 59u8, 113u8, 27u8,
-                            226u8, 231u8, 161u8, 12u8, 15u8, 216u8, 239u8, 161u8, 40u8, 104u8,
-                            165u8, 148u8, 252u8, 65u8, 204u8, 181u8, 72u8, 3u8, 41u8, 129u8, 160u8,
+                            69u8, 166u8, 84u8, 150u8, 209u8, 38u8, 239u8, 113u8, 28u8, 84u8, 226u8,
+                            66u8, 226u8, 240u8, 129u8, 91u8, 1u8, 26u8, 59u8, 151u8, 242u8, 17u8,
+                            149u8, 22u8, 80u8, 175u8, 162u8, 193u8, 158u8, 190u8, 192u8, 252u8,
                         ],
                     )
                 }
@@ -15364,16 +15498,21 @@ pub mod api {
                 pub fn confirm_miner_vacation(
                     &self,
                     task_id: types::confirm_miner_vacation::TaskId,
+                    miner_type: types::confirm_miner_vacation::MinerType,
                 ) -> ::subxt::ext::subxt_core::tx::payload::StaticPayload<types::ConfirmMinerVacation>
                 {
                     ::subxt::ext::subxt_core::tx::payload::StaticPayload::new_static(
                         "TaskManagement",
                         "confirm_miner_vacation",
-                        types::ConfirmMinerVacation { task_id },
+                        types::ConfirmMinerVacation {
+                            task_id,
+                            miner_type,
+                        },
                         [
-                            59u8, 61u8, 124u8, 133u8, 42u8, 125u8, 128u8, 6u8, 249u8, 164u8, 224u8,
-                            173u8, 22u8, 116u8, 117u8, 35u8, 39u8, 120u8, 131u8, 235u8, 40u8, 87u8,
-                            84u8, 120u8, 110u8, 65u8, 154u8, 195u8, 21u8, 18u8, 156u8, 56u8,
+                            121u8, 155u8, 220u8, 197u8, 163u8, 120u8, 147u8, 196u8, 9u8, 213u8,
+                            91u8, 37u8, 78u8, 117u8, 108u8, 1u8, 249u8, 236u8, 192u8, 22u8, 199u8,
+                            128u8, 147u8, 181u8, 226u8, 149u8, 227u8, 67u8, 161u8, 168u8, 75u8,
+                            248u8,
                         ],
                     )
                 }
@@ -15459,7 +15598,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type AssignedMiner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type TaskKind =
                     runtime_types::cyborg_primitives::task::TaskKind<::core::primitive::u32>;
@@ -15603,7 +15744,9 @@ pub mod api {
                     use super::runtime_types;
                     pub type TaskAllocations = (
                         ::subxt::ext::subxt_core::utils::AccountId32,
-                        ::core::primitive::u64,
+                        runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                     );
                     pub type Param0 = ::core::primitive::u64;
                 }
@@ -15724,10 +15867,10 @@ pub mod api {
                         "TaskAllocations",
                         (),
                         [
-                            245u8, 108u8, 202u8, 240u8, 1u8, 7u8, 254u8, 252u8, 205u8, 32u8, 226u8,
-                            108u8, 107u8, 55u8, 163u8, 188u8, 103u8, 214u8, 223u8, 104u8, 110u8,
-                            216u8, 222u8, 23u8, 127u8, 140u8, 122u8, 221u8, 250u8, 26u8, 168u8,
-                            236u8,
+                            232u8, 188u8, 42u8, 109u8, 42u8, 237u8, 157u8, 203u8, 58u8, 216u8,
+                            39u8, 134u8, 215u8, 247u8, 75u8, 41u8, 108u8, 108u8, 160u8, 164u8,
+                            31u8, 225u8, 13u8, 241u8, 73u8, 136u8, 147u8, 149u8, 119u8, 87u8,
+                            191u8, 80u8,
                         ],
                     )
                 }
@@ -15751,10 +15894,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            245u8, 108u8, 202u8, 240u8, 1u8, 7u8, 254u8, 252u8, 205u8, 32u8, 226u8,
-                            108u8, 107u8, 55u8, 163u8, 188u8, 103u8, 214u8, 223u8, 104u8, 110u8,
-                            216u8, 222u8, 23u8, 127u8, 140u8, 122u8, 221u8, 250u8, 26u8, 168u8,
-                            236u8,
+                            232u8, 188u8, 42u8, 109u8, 42u8, 237u8, 157u8, 203u8, 58u8, 216u8,
+                            39u8, 134u8, 215u8, 247u8, 75u8, 41u8, 108u8, 108u8, 160u8, 164u8,
+                            31u8, 225u8, 13u8, 241u8, 73u8, 136u8, 147u8, 149u8, 119u8, 87u8,
+                            191u8, 80u8,
                         ],
                     )
                 }
@@ -16168,7 +16311,9 @@ pub mod api {
                 use super::runtime_types;
                 pub type Miner = (
                     ::subxt::ext::subxt_core::utils::AccountId32,
-                    ::core::primitive::u64,
+                    runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                 );
                 pub type Online = ::core::primitive::bool;
                 pub type Available = ::core::primitive::bool;
@@ -16296,9 +16441,10 @@ pub mod api {
                         "MinerStatusEntriesPerPeriod",
                         (),
                         [
-                            160u8, 144u8, 110u8, 96u8, 202u8, 147u8, 60u8, 189u8, 107u8, 113u8,
-                            206u8, 159u8, 169u8, 218u8, 32u8, 216u8, 13u8, 19u8, 102u8, 65u8, 76u8,
-                            32u8, 79u8, 213u8, 204u8, 4u8, 109u8, 116u8, 177u8, 179u8, 33u8, 236u8,
+                            199u8, 184u8, 208u8, 246u8, 233u8, 66u8, 169u8, 219u8, 209u8, 190u8,
+                            136u8, 145u8, 100u8, 227u8, 226u8, 101u8, 185u8, 121u8, 242u8, 3u8,
+                            191u8, 10u8, 19u8, 32u8, 252u8, 239u8, 224u8, 2u8, 140u8, 25u8, 43u8,
+                            211u8,
                         ],
                     )
                 }
@@ -16327,9 +16473,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            160u8, 144u8, 110u8, 96u8, 202u8, 147u8, 60u8, 189u8, 107u8, 113u8,
-                            206u8, 159u8, 169u8, 218u8, 32u8, 216u8, 13u8, 19u8, 102u8, 65u8, 76u8,
-                            32u8, 79u8, 213u8, 204u8, 4u8, 109u8, 116u8, 177u8, 179u8, 33u8, 236u8,
+                            199u8, 184u8, 208u8, 246u8, 233u8, 66u8, 169u8, 219u8, 209u8, 190u8,
+                            136u8, 145u8, 100u8, 227u8, 226u8, 101u8, 185u8, 121u8, 242u8, 3u8,
+                            191u8, 10u8, 19u8, 32u8, 252u8, 239u8, 224u8, 2u8, 140u8, 25u8, 43u8,
+                            211u8,
                         ],
                     )
                 }
@@ -16352,10 +16499,10 @@ pub mod api {
                         "SubmittedPerPeriod",
                         (),
                         [
-                            199u8, 31u8, 134u8, 158u8, 20u8, 221u8, 92u8, 177u8, 125u8, 152u8,
-                            181u8, 7u8, 241u8, 179u8, 207u8, 220u8, 200u8, 15u8, 204u8, 187u8,
-                            140u8, 175u8, 178u8, 164u8, 145u8, 232u8, 189u8, 230u8, 143u8, 225u8,
-                            205u8, 5u8,
+                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
+                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
+                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
+                            188u8, 2u8,
                         ],
                     )
                 }
@@ -16383,10 +16530,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            199u8, 31u8, 134u8, 158u8, 20u8, 221u8, 92u8, 177u8, 125u8, 152u8,
-                            181u8, 7u8, 241u8, 179u8, 207u8, 220u8, 200u8, 15u8, 204u8, 187u8,
-                            140u8, 175u8, 178u8, 164u8, 145u8, 232u8, 189u8, 230u8, 143u8, 225u8,
-                            205u8, 5u8,
+                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
+                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
+                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
+                            188u8, 2u8,
                         ],
                     )
                 }
@@ -16425,10 +16572,10 @@ pub mod api {
                             ),
                         ),
                         [
-                            199u8, 31u8, 134u8, 158u8, 20u8, 221u8, 92u8, 177u8, 125u8, 152u8,
-                            181u8, 7u8, 241u8, 179u8, 207u8, 220u8, 200u8, 15u8, 204u8, 187u8,
-                            140u8, 175u8, 178u8, 164u8, 145u8, 232u8, 189u8, 230u8, 143u8, 225u8,
-                            205u8, 5u8,
+                            219u8, 37u8, 17u8, 204u8, 99u8, 246u8, 215u8, 108u8, 151u8, 172u8,
+                            221u8, 98u8, 175u8, 218u8, 19u8, 16u8, 37u8, 165u8, 174u8, 182u8,
+                            115u8, 198u8, 199u8, 147u8, 205u8, 26u8, 159u8, 65u8, 220u8, 86u8,
+                            188u8, 2u8,
                         ],
                     )
                 }
@@ -16452,10 +16599,9 @@ pub mod api {
                         "ResultingMinerStatusPercentages",
                         (),
                         [
-                            226u8, 70u8, 169u8, 200u8, 40u8, 35u8, 107u8, 126u8, 234u8, 239u8,
-                            206u8, 251u8, 48u8, 115u8, 207u8, 4u8, 119u8, 174u8, 132u8, 56u8,
-                            122u8, 241u8, 227u8, 29u8, 122u8, 240u8, 125u8, 31u8, 79u8, 27u8,
-                            207u8, 126u8,
+                            212u8, 231u8, 168u8, 113u8, 19u8, 16u8, 243u8, 5u8, 38u8, 162u8, 216u8,
+                            120u8, 112u8, 101u8, 109u8, 142u8, 76u8, 11u8, 198u8, 138u8, 200u8,
+                            156u8, 116u8, 67u8, 233u8, 28u8, 32u8, 74u8, 38u8, 218u8, 207u8, 59u8,
                         ],
                     )
                 }
@@ -16484,10 +16630,9 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            226u8, 70u8, 169u8, 200u8, 40u8, 35u8, 107u8, 126u8, 234u8, 239u8,
-                            206u8, 251u8, 48u8, 115u8, 207u8, 4u8, 119u8, 174u8, 132u8, 56u8,
-                            122u8, 241u8, 227u8, 29u8, 122u8, 240u8, 125u8, 31u8, 79u8, 27u8,
-                            207u8, 126u8,
+                            212u8, 231u8, 168u8, 113u8, 19u8, 16u8, 243u8, 5u8, 38u8, 162u8, 216u8,
+                            120u8, 112u8, 101u8, 109u8, 142u8, 76u8, 11u8, 198u8, 138u8, 200u8,
+                            156u8, 116u8, 67u8, 233u8, 28u8, 32u8, 74u8, 38u8, 218u8, 207u8, 59u8,
                         ],
                     )
                 }
@@ -16510,9 +16655,10 @@ pub mod api {
                         "ResultingMinerStatus",
                         (),
                         [
-                            25u8, 196u8, 159u8, 168u8, 68u8, 152u8, 36u8, 84u8, 37u8, 83u8, 83u8,
-                            128u8, 72u8, 244u8, 14u8, 226u8, 142u8, 124u8, 175u8, 213u8, 25u8,
-                            31u8, 205u8, 20u8, 10u8, 137u8, 120u8, 74u8, 231u8, 179u8, 62u8, 135u8,
+                            101u8, 209u8, 235u8, 233u8, 95u8, 136u8, 148u8, 26u8, 214u8, 52u8,
+                            50u8, 80u8, 66u8, 115u8, 33u8, 173u8, 102u8, 82u8, 91u8, 236u8, 52u8,
+                            31u8, 238u8, 185u8, 61u8, 195u8, 105u8, 48u8, 193u8, 158u8, 61u8,
+                            100u8,
                         ],
                     )
                 }
@@ -16540,9 +16686,10 @@ pub mod api {
                             _0.borrow(),
                         ),
                         [
-                            25u8, 196u8, 159u8, 168u8, 68u8, 152u8, 36u8, 84u8, 37u8, 83u8, 83u8,
-                            128u8, 72u8, 244u8, 14u8, 226u8, 142u8, 124u8, 175u8, 213u8, 25u8,
-                            31u8, 205u8, 20u8, 10u8, 137u8, 120u8, 74u8, 231u8, 179u8, 62u8, 135u8,
+                            101u8, 209u8, 235u8, 233u8, 95u8, 136u8, 148u8, 26u8, 214u8, 52u8,
+                            50u8, 80u8, 66u8, 115u8, 33u8, 173u8, 102u8, 82u8, 91u8, 236u8, 52u8,
+                            31u8, 238u8, 185u8, 61u8, 195u8, 105u8, 48u8, 193u8, 158u8, 61u8,
+                            100u8,
                         ],
                     )
                 }
@@ -19276,6 +19423,7 @@ pub mod api {
                     :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
                     :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
                     Debug,
+                    Clone,
                 )]
                 # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
                 #[codec(dumb_trait_bound)]
@@ -19889,14 +20037,18 @@ pub mod api {
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
                 pub struct Miner<_0, _1, _2> {
-                    pub id: ::core::primitive::u64,
+                    pub id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                        ::core::primitive::u8,
+                    >,
                     pub owner: _0,
                     pub location: runtime_types::cyborg_primitives::miner::Location,
                     pub specs: runtime_types::cyborg_primitives::miner::MinerSpecs,
                     pub reputation: runtime_types::cyborg_primitives::miner::MinerReputation<_1>,
                     pub current_task: ::core::option::Option<_2>,
                     pub start_block: _1,
-                    pub status: runtime_types::cyborg_primitives::miner::MinerStatusType,
+                    pub oracle_status: runtime_types::cyborg_primitives::miner::OracleStatus,
+                    pub operational_status:
+                        runtime_types::cyborg_primitives::miner::OperationalStatus,
                     pub status_last_updated: _1,
                     pub api: runtime_types::cyborg_primitives::miner::MinerAPI,
                     pub last_status_check: _2,
@@ -19979,14 +20131,33 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                pub enum MinerStatusType {
+                pub enum MinerType {
                     #[codec(index = 0)]
-                    Active,
+                    Cloud,
+                    #[codec(index = 1)]
+                    Edge,
+                }
+                #[derive(
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
+                    :: subxt :: ext :: subxt_core :: ext :: codec :: Encode,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_decode :: DecodeAsType,
+                    :: subxt :: ext :: subxt_core :: ext :: scale_encode :: EncodeAsType,
+                    Debug,
+                )]
+                # [codec (crate = :: subxt :: ext :: subxt_core :: ext :: codec)]
+                #[codec(dumb_trait_bound)]
+                #[decode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_decode"
+                )]
+                #[encode_as_type(
+                    crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
+                )]
+                pub enum OperationalStatus {
+                    #[codec(index = 0)]
+                    Available,
                     #[codec(index = 1)]
                     Busy,
                     #[codec(index = 2)]
-                    Inactive,
-                    #[codec(index = 3)]
                     Suspended,
                 }
                 #[derive(
@@ -20004,11 +20175,11 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                pub enum MinerType {
+                pub enum OracleStatus {
                     #[codec(index = 0)]
-                    Cloud,
+                    Online,
                     #[codec(index = 1)]
-                    Edge,
+                    Offline,
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -20079,7 +20250,12 @@ pub mod api {
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
                 pub struct OracleMinerFormat<_0> {
-                    pub id: (_0, ::core::primitive::u64),
+                    pub id: (
+                        _0,
+                        runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
+                    ),
                     pub miner_type: runtime_types::cyborg_primitives::miner::MinerType,
                 }
                 #[derive(
@@ -21450,7 +21626,7 @@ pub mod api {
                     #[doc = "Sender does not have permission"]
                     NoPermission,
                     #[codec(index = 1)]
-                    #[doc = "Feeder has already feeded at this block"]
+                    #[doc = "Feeder has already fed at this block"]
                     AlreadyFeeded,
                 }
                 #[derive(
@@ -22307,6 +22483,8 @@ pub mod api {
                     #[doc = "Registers a Miner with either a domain and initialize it with an inactive status."]
                     register_miner {
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
+                        miner_uuid:
+                            ::subxt::ext::subxt_core::alloc::vec::Vec<::core::primitive::u8>,
                         domain: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
                         >,
@@ -22320,19 +22498,26 @@ pub mod api {
                     #[doc = "Remove a miner from storage an deactivates it"]
                     remove_miner {
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                     },
                     #[codec(index = 2)]
-                    #[doc = "Switches the visibility of a miner between active and inactive."]
-                    toggle_miner_visibility {
+                    #[doc = "Updates the oracle status (callable by oracle feeder)"]
+                    update_oracle_status {
+                        miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
-                        miner_id: ::core::primitive::u64,
-                        visibility: ::core::primitive::bool,
+                        online: ::core::primitive::bool,
                     },
                     #[codec(index = 3)]
                     penalize_miner {
                         miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
                         penalty: ::core::primitive::i32,
                         reason: runtime_types::pallet_edge_connect::pallet::PenaltyReason,
@@ -22341,7 +22526,9 @@ pub mod api {
                     #[doc = "Manually suspend a miner (root only)"]
                     suspend_miner {
                         miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
                         blocks: ::core::primitive::u32,
                         reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
@@ -22350,7 +22537,9 @@ pub mod api {
                     #[doc = "Manually ban a miner (root only)"]
                     ban_miner {
                         miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
                         reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
                     },
@@ -22358,8 +22547,19 @@ pub mod api {
                     #[doc = "Lift suspension from a miner (root only)"]
                     unsuspend_miner {
                         miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         miner_type: runtime_types::cyborg_primitives::miner::MinerType,
+                    },
+                    #[codec(index = 7)]
+                    #[doc = "Updates the operational status (callable by miner itself)"]
+                    update_operational_status {
+                        miner_type: runtime_types::cyborg_primitives::miner::MinerType,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
+                        status: runtime_types::cyborg_primitives::miner::OperationalStatus,
                     },
                 }
                 #[derive(
@@ -22401,6 +22601,10 @@ pub mod api {
                     #[codec(index = 6)]
                     #[doc = "Miner is inactive"]
                     MinerIsInactive,
+                    #[codec(index = 7)]
+                    NotAuthorized,
+                    #[codec(index = 8)]
+                    UuidTooLong,
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -22430,7 +22634,9 @@ pub mod api {
                         creator: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         domain: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
@@ -22445,7 +22651,9 @@ pub mod api {
                         creator: ::subxt::ext::subxt_core::utils::AccountId32,
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         domain: runtime_types::bounded_collections::bounded_vec::BoundedVec<
                             ::core::primitive::u8,
@@ -22458,62 +22666,83 @@ pub mod api {
                     #[doc = "- `miner_id`: The ID of the miner that was removed."]
                     MinerRemoved {
                         creator: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                     },
                     #[codec(index = 3)]
-                    #[doc = "Event emitted when a miner's status is updated (e.g., toggling visibility)."]
-                    #[doc = ""]
-                    #[doc = "- `creator`: The account ID of the miner's creator."]
-                    #[doc = "- `miner_id`: The ID of the miner whose status was updated."]
-                    #[doc = "- `miner_status`: The new status of the miner, either active or inactive."]
-                    MinerStatusUpdated {
-                        creator: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
-                        miner_status: runtime_types::cyborg_primitives::miner::MinerStatusType,
+                    OracleStatusUpdated {
+                        worker: (
+                            ::subxt::ext::subxt_core::utils::AccountId32,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
+                        ),
+                        online: ::core::primitive::bool,
                     },
                     #[codec(index = 4)]
+                    OperationalStatusUpdated {
+                        worker: (
+                            ::subxt::ext::subxt_core::utils::AccountId32,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
+                        ),
+                        status: runtime_types::cyborg_primitives::miner::OperationalStatus,
+                    },
+                    #[codec(index = 5)]
                     #[doc = "Event emitted when a miner is penalized"]
                     MinerPenalized {
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         penalty: ::core::primitive::i32,
                         reason: runtime_types::pallet_edge_connect::pallet::PenaltyReason,
                     },
-                    #[codec(index = 5)]
+                    #[codec(index = 6)]
                     #[doc = "Event emitted when a miner is suspended"]
                     MinerSuspended {
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         until_block: ::core::primitive::u32,
                     },
-                    #[codec(index = 6)]
+                    #[codec(index = 7)]
                     #[doc = "Event emitted when a miner is put under review"]
                     MinerUnderReview {
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
-                        ),
-                        reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
-                    },
-                    #[codec(index = 7)]
-                    #[doc = "Event emitted when a miner is banned"]
-                    MinerBanned {
-                        miner: (
-                            ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
                     },
                     #[codec(index = 8)]
+                    #[doc = "Event emitted when a miner is banned"]
+                    MinerBanned {
+                        miner: (
+                            ::subxt::ext::subxt_core::utils::AccountId32,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
+                        ),
+                        reason: runtime_types::cyborg_primitives::miner::SuspensionReason,
+                    },
+                    #[codec(index = 9)]
                     #[doc = "Event emitted when a miner is unsuspended"]
                     MinerUnsuspended {
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                     },
                 }
@@ -23517,7 +23746,9 @@ pub mod api {
                     UpdateFromAggregatedMinerInfo {
                         miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         online: ::core::primitive::bool,
                         available: ::core::primitive::bool,
@@ -23724,7 +23955,9 @@ pub mod api {
                     task_scheduler {
                         task_kind: runtime_types::cyborg_primitives::task::TaskSubmissionData,
                         miner_owner: ::subxt::ext::subxt_core::utils::AccountId32,
-                        miner_id: ::core::primitive::u64,
+                        miner_id: runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                            ::core::primitive::u8,
+                        >,
                         compute_hours_deposit: ::core::option::Option<::core::primitive::u32>,
                     },
                     #[codec(index = 1)]
@@ -23741,7 +23974,10 @@ pub mod api {
                     #[codec(index = 6)]
                     #[doc = "miner confirms that it has reset itself"]
                     #[doc = "Stopped to vacated"]
-                    confirm_miner_vacation { task_id: ::core::primitive::u64 },
+                    confirm_miner_vacation {
+                        task_id: ::core::primitive::u64,
+                        miner_type: runtime_types::cyborg_primitives::miner::MinerType,
+                    },
                     #[codec(index = 4)]
                     set_gatekeeper {
                         new_gatekeeper: ::subxt::ext::subxt_core::utils::AccountId32,
@@ -23813,6 +24049,21 @@ pub mod api {
                     ModelNotFound,
                     #[codec(index = 18)]
                     TaskReceptionAlreadyConfirmed,
+                    #[codec(index = 19)]
+                    #[doc = "Error indicating that the miner does not exist"]
+                    MinerDoesNotExist,
+                    #[codec(index = 20)]
+                    #[doc = "Error indicating that the miner is busy"]
+                    MinerIsBusy,
+                    #[codec(index = 21)]
+                    #[doc = "Error indicating insufficient reputation"]
+                    InsufficientReputation,
+                    #[codec(index = 22)]
+                    #[doc = "Error indicating that the miner is inactive"]
+                    MinerIsInactive,
+                    #[codec(index = 23)]
+                    #[doc = "Error indicating that the miner is suspended"]
+                    MinerSuspended,
                 }
                 #[derive(
                     :: subxt :: ext :: subxt_core :: ext :: codec :: Decode,
@@ -23837,7 +24088,9 @@ pub mod api {
                     TaskScheduled {
                         assigned_miner: (
                             ::subxt::ext::subxt_core::utils::AccountId32,
-                            ::core::primitive::u64,
+                            runtime_types::bounded_collections::bounded_vec::BoundedVec<
+                                ::core::primitive::u8,
+                            >,
                         ),
                         task_kind: runtime_types::cyborg_primitives::task::TaskKind<
                             ::core::primitive::u32,

--- a/src/tx_queue.rs
+++ b/src/tx_queue.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::error::Result;
 use once_cell::sync::OnceCell;
 use std::{
@@ -20,7 +21,7 @@ type TxExecutor =
 #[derive(Debug)]
 pub enum TxOutput {
     OracleFeedSuccess,
-    ProofVerificationSuccess,
+    // ProofVerificationSuccess,
 }
 
 pub struct Transaction {


### PR DESCRIPTION

* **Oracle Feeder:**

  * Integrated the latest parachain interface updates.
  * Refactored logic to use the new single `MinerId` identifier instead of `(AccountId, MinerId)`.

* **Oracle Format & Value:**

  * Updated both to store and process only `MinerId`.

* **General Updates:**

  * Modified dependent components and interfaces impacted by the new Oracle structure.
